### PR TITLE
Do not read cinder backend info from job name

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -40,11 +40,11 @@ from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source import speed_index
 from cibyl.utils.dicts import subset
 from cibyl.utils.files import get_file_name_from_path
-from cibyl.utils.filtering import (CINDER_BACKEND_PATTERN, DEPLOYMENT_PATTERN,
-                                   DVR_PATTERN_NAME, IP_PATTERN,
-                                   NETWORK_BACKEND_PATTERN, RELEASE_PATTERN,
-                                   SERVICES_PATTERN, TOPOLOGY_PATTERN,
-                                   apply_filters, filter_topology,
+from cibyl.utils.filtering import (DEPLOYMENT_PATTERN, DVR_PATTERN_NAME,
+                                   IP_PATTERN, NETWORK_BACKEND_PATTERN,
+                                   RELEASE_PATTERN, SERVICES_PATTERN,
+                                   TOPOLOGY_PATTERN, apply_filters,
+                                   filter_topology,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match, satisfy_regex_match)
 
@@ -203,9 +203,7 @@ class Jenkins(SourceExtension):
 
         missing_cinder_backend = not bool(job.get("cinder_backend", ""))
         if missing_cinder_backend and ("cinder_backend" in kwargs or spec):
-            cinder_backend = detect_job_info_regex(job_name,
-                                                   CINDER_BACKEND_PATTERN)
-            job["cinder_backend"] = cinder_backend
+            job["cinder_backend"] = ""
 
         missing_ip_version = "ip_version" not in job or not job["ip_version"]
         if missing_ip_version and ("ip_version" in kwargs or spec):

--- a/cibyl/plugins/openstack/sources/jenkins_job_builder.py
+++ b/cibyl/plugins/openstack/sources/jenkins_job_builder.py
@@ -147,7 +147,7 @@ class JenkinsJobBuilder(SourceExtension):
                 return None
         return ip_version_str
 
-    @speed_index({'base': 3})
+    @speed_index({'base': 3, 'cinder_backend': 1})
     def get_deployment(self, **kwargs):
         """
         extract different aspects of deployment information

--- a/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
@@ -802,12 +802,19 @@ tripleo_ironic_conductor.service loaded    active     running
         job_names = ['test_17.3_ipv4_job_2comp_1cont_geneve_swift',
                      'test_16_ipv6_job_1comp_2cont_lvm', 'test_job']
         response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
         for job_name in job_names:
             response['jobs'].append({'_class': 'org.job.WorkflowJob',
                                      'name': job_name, 'url': 'url',
-                                     'lastBuild': None})
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
 
-        self.jenkins.send_request = Mock(side_effect=[response])
+        artifacts = [
+                get_yaml_overcloud(cinder_backend="swift"),
+                get_yaml_overcloud(cinder_backend="lvm"),
+                get_yaml_overcloud(cinder_backend="")]
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
         args = {
             "cinder_backend": Argument("cinder_backend", str, "",
                                        value=["swift"])


### PR DESCRIPTION
Extracting the cinder backend information from the job name is
error-prone. This change removes the functionality, reading it only from
the logs. It also increases the speed index of jjb source for the
--cinder-backend argument so it'll be picked up over jenkins.
