### PR TITLE
Support filtering by test class name in Jenkins

### DIFF
--- a/cibyl/models/ci/base/build.py
+++ b/cibyl/models/ci/base/build.py
@@ -48,7 +48,7 @@ class Build(Model):
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--tests', arg_type=str,
                                    nargs='*', func='get_tests',
-                                   description="Job test")]
+                                   description="Test name or test suite name")]
         },
         'stages': {
             'attr_type': Stage,

--- a/cibyl/models/ci/zuul/build.py
+++ b/cibyl/models/ci/zuul/build.py
@@ -79,7 +79,7 @@ class Build(Model):
                 Argument(
                     name='--tests', arg_type=str,
                     nargs='*', func='get_tests',
-                    description="Fetch build tests"
+                    description="Test name or test suite name"
                 )
             ]
         }

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -125,9 +125,14 @@ def get_test_filters(**kwargs: Argument) -> List[Callable]:
     tests_arg = kwargs.get('tests')
     if tests_arg and tests_arg.value:
         pattern = re.compile("|".join(tests_arg.value))
-        checks_to_apply.append(partial(satisfy_regex_match,
-                                       pattern=pattern,
-                                       field_to_check="name"))
+        filter_name = partial(satisfy_regex_match, pattern=pattern,
+                              field_to_check="name")
+        # check also whether the class name matches the input
+        filter_class = partial(satisfy_regex_match, pattern=pattern,
+                               field_to_check="className")
+
+        checks_to_apply.append(lambda model:
+                               filter_name(model) or filter_class(model))
 
     tests_results = kwargs.get('test_result')
     if tests_results and tests_results.value:

--- a/docs/source/usage/cli.rst
+++ b/docs/source/usage/cli.rst
@@ -172,6 +172,10 @@ or list the  tests that contain the string `123` in their name::
 
     cibyl query --jobs --last-build --tests 123
 
+.. note:: The --tests argument can filter by test name or by test class name.
+   Typically filtering by a individual test is probably too fine-grained, so
+   filtering by the test suite name is also supported in the argument.
+
 or list only the failing tests::
 
     cibyl query --jobs --last-build --test-result FAILED


### PR DESCRIPTION
Filtering tests with the --tests argument by test name only might be too
fine-grained for most use cases. Most use cases will involve filtering
by test suite rather than individual tests. This change modifies the
argument to suppport filtering both by test name and test class name
in the Jenkins source.
