### PR TITLE
Expose class name in Zuul tests

### DIFF
--- a/cibyl/models/ci/zuul/test.py
+++ b/cibyl/models/ci/zuul/test.py
@@ -20,7 +20,6 @@ from overrides import overrides
 from strenum import StrEnum
 
 from cibyl.models.ci.base.test import Test as BaseTest
-from cibyl.utils.dicts import nsubset
 
 
 class TestKind(StrEnum):
@@ -67,7 +66,7 @@ class Test(BaseTest):
         """Page where more information about the test can be obtained."""
 
     API = {
-        **nsubset(BaseTest.API, ['class_name']),
+        **BaseTest.API,
         'kind': {
             'attr_type': TestKind,
             'arguments': []

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -295,6 +295,9 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
             result.add(self.palette.blue('Result: '), 1)
             result[-1].append(self._get_colored_test_result(test.result.value))
 
+            if test.class_name.value:
+                result.add(self.palette.blue('Class name: '), 1)
+                result[-1].append(test.class_name.value)
             if self.verbosity > 1:
                 result.add(self.palette.blue('URL: '), 1)
                 result[-1].append(test.url.value)

--- a/cibyl/outputs/cli/ci/system/impls/zuul/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/serialized.py
@@ -221,7 +221,8 @@ class SerializedZuulSystemPrinter(SerializedBaseSystemPrinter[PROV], ABC):
             'type': test.kind.value,
             'duration': test.duration.value,
             'result': test.result.value,
-            'url': test.url.value
+            'url': test.url.value,
+            'class_name': test.class_name.value
         }
 
         return self.provider.dump(result)

--- a/cibyl/sources/zuul/output.py
+++ b/cibyl/sources/zuul/output.py
@@ -253,7 +253,8 @@ class QueryOutputBuilder:
                     status=test.status,
                     duration=test.duration,
                     url=test.url
-                )
+                ),
+                class_name=test.class_name
             )
 
             suite.add_test(model)

--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -782,6 +782,16 @@ class TestResponse:
         return self.data.name
 
     @property
+    def class_name(self) -> str:
+        """
+        :return: Name of the class the test belongs to.
+        """
+        if hasattr(self.data, "class_name"):
+            return self.data.class_name
+        else:
+            return ""
+
+    @property
     def status(self) -> TestStatus:
         """
         :return: Result of the test case.


### PR DESCRIPTION
The zuul model for tests was not exposing the class name attribute for
tempest tests, which is a commonly used field. This change adds the
attribute to the model API and modifies the Zuul printers to show
it.
