### PR TITLE
Support filtering by class name in Zuul

### DIFF
--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -381,7 +381,8 @@ class TestsRequest(Request):
         self._build = build
 
     def with_name(self, *pattern: str) -> 'TestsRequest':
-        """Will limit request to tests whose name follows a certain pattern.
+        """Will limit request to tests whose name or class name follow a
+        certain pattern.
 
         :param pattern: Regex pattern for the desired test name.
         :return: The request's instance.
@@ -390,7 +391,9 @@ class TestsRequest(Request):
         def test(response):
             return any(
                 matches_regex(patt, response.name) for patt in pattern
-            )
+                ) or any(
+                matches_regex(patt, response.class_name) for patt in pattern
+                )
 
         self._filters.append(test)
         return self

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -35,9 +35,11 @@ class TestTestsRequest(TestCase):
         """
         test1 = Mock()
         test1.name = 'test1'
+        test1.class_name = 'class1'
 
         test2 = Mock()
         test2.name = 'test2'
+        test2.class_name = 'class2'
 
         suite = Mock()
         suite.tests = [test1, test2]
@@ -55,6 +57,64 @@ class TestTestsRequest(TestCase):
 
         self.assertEqual(1, len(result))
         self.assertEqual(test1, result[0].data)
+
+    def test_with_name_class_name(self):
+        """Checks that the request can filter tests by class name.
+        """
+        test1 = Mock()
+        test1.name = 'test1'
+        test1.class_name = 'class1'
+
+        test2 = Mock()
+        test2.name = 'test2'
+        test2.class_name = 'class2'
+
+        suite = Mock()
+        suite.tests = [test1, test2]
+
+        build = Mock()
+        build.tests = Mock()
+        build.tests.return_value = [suite]
+
+        name = test1.class_name
+
+        request = TestsRequest(build)
+        request.with_name(name)
+
+        result = list(request.get())
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(test1, result[0].data)
+
+    def test_with_name_class_name_and_name(self):
+        """Checks that the request can filter tests by class name and name at
+        the same time.
+        """
+        test1 = Mock()
+        test1.name = 'test1'
+        test1.class_name = 'class1'
+
+        test2 = Mock()
+        test2.name = 'test2'
+        test2.class_name = 'class2'
+
+        suite = Mock()
+        suite.tests = [test1, test2]
+
+        build = Mock()
+        build.tests = Mock()
+        build.tests.return_value = [suite]
+
+        name = (test1.class_name, test2.class_name)
+
+        request = TestsRequest(build)
+        request.with_name(*name)
+
+        result = list(request.get())
+
+        self.assertEqual(2, len(result))
+        self.assertEqual(test1, result[0].data)
+        self.assertEqual(test2, result[1].data)
 
     @parameterized.expand(['SUCCESS', 'success'])
     def test_with_status(self, status: str):


### PR DESCRIPTION
Filtering tests with the --tests argument by test name only might be too
fine-grained for most use cases. Most use cases will involve filtering
by test suite rather than individual tests. This change modifies the
argument to suppport filtering both by test name and test class name
in the Zuul source.
