### PR TITLE
Print correct build duration in zuul systems

### DIFF
--- a/cibyl/outputs/cli/ci/system/common/builds.py
+++ b/cibyl/outputs/cli/ci/system/common/builds.py
@@ -58,11 +58,13 @@ def has_duration_section(build: Build) -> bool:
     return build.duration.value
 
 
-def get_duration_section(palette: ColorPalette, build: Build) -> str:
+def get_duration_section(palette: ColorPalette, build: Build,
+                         unit: str = "ms") -> str:
     """Generates the text describing the duration of a build.
 
     :param palette: The palette of colors to follow.
     :param build: The build to get the data from.
+    :param unit: The unit the duration is in.
     :return: The text with the duration of the build.
     """
     if not has_duration_section(build):
@@ -71,6 +73,6 @@ def get_duration_section(palette: ColorPalette, build: Build) -> str:
     text = IndentedTextBuilder()
 
     text.add(palette.blue('Duration: '), 0)
-    text[-1].append(f'{as_minutes(build.duration.value):.2f}min')
+    text[-1].append(f'{as_minutes(build.duration.value, unit=unit):.2f}min')
 
     return text.build()

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored/cascades/job.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored/cascades/job.py
@@ -114,7 +114,9 @@ class JobCascade(ColoredPrinter):
 
         if self.verbosity > 0:
             if build.duration.value:
-                result.add(get_duration_section(self.palette, build), 1)
+                build_duration = get_duration_section(self.palette, build,
+                                                      unit="s")
+                result.add(build_duration, 1)
 
         if self.query >= QueryType.TESTS:
             result.add(self.palette.blue('Test Suites: '), 1)


### PR DESCRIPTION
The zuul system printer was storing the build duration in seconds, but
converting it to minutes assuming it was in milliseconds, due to missing
"unit" parameter. This commit makes sure the unit is passed all the way
through to the "as_minutes" function and the duration is correctly
shown.
