### PR TITLE
Implementing '--last-completed-build' on the Zuul source

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -75,22 +75,38 @@ class QuerySelector:
         if 'projects' in kwargs:
             result |= QueryType.PROJECTS
 
-        pipeline_args = subset(kwargs, ['pipelines', 'fetch_pipelines'])
+        pipeline_args = subset(
+            kwargs,
+            ['pipelines', 'fetch_pipelines']
+        )
+
         if pipeline_args:
             result |= QueryType.PIPELINES
 
-        job_args = subset(kwargs, ["jobs", "job_url", "fetch_hierarchy"])
+        job_args = subset(
+            kwargs,
+            ["jobs", "job_url", "fetch_hierarchy"]
+        )
+
         if job_args:
             result |= QueryType.JOBS
 
         if 'variants' in kwargs:
             result |= QueryType.VARIANTS
 
-        build_args = subset(kwargs, ["builds", "last_build", "build_status"])
+        build_args = subset(
+            kwargs,
+            ["builds", "build_status", "last_build", "last_completed_build"]
+        )
+
         if build_args:
             result |= QueryType.BUILDS
 
-        test_args = subset(kwargs, ["tests", "test_result", "test_duration"])
+        test_args = subset(
+            kwargs,
+            ["tests", "test_result", "test_duration"]
+        )
+
         if test_args:
             result |= QueryType.TESTS
 

--- a/cibyl/models/ci/base/job.py
+++ b/cibyl/models/ci/base/job.py
@@ -45,7 +45,11 @@ class Job(Model):
                                    description="Job builds"),
                           Argument(name='--last-build', arg_type=str,
                                    func='get_builds', nargs=0,
-                                   description="Last build for job")]
+                                   description="Last build for job"),
+                          Argument(name='--last-completed-build',
+                                   arg_type=str, func='get_builds', nargs=0,
+                                   description="Last successful build for "
+                                               "job")]
         }
     }
 

--- a/cibyl/sources/zuul/apis/__init__.py
+++ b/cibyl/sources/zuul/apis/__init__.py
@@ -85,7 +85,7 @@ class ZuulBuildAPI(Closeable, ABC):
     def result(self):
         """
         :return: The build's result.
-        :rtype: str
+        :rtype: str or None
         """
         return self._build['result']
 

--- a/cibyl/sources/zuul/arguments.py
+++ b/cibyl/sources/zuul/arguments.py
@@ -77,7 +77,12 @@ class ArgumentReview:
         """
         return any(
             arg in kwargs
-            for arg in ('builds', 'last_build', 'build_status')
+            for arg in (
+                'builds',
+                'build_status',
+                'last_build',
+                'last_completed_build'
+            )
         )
 
     def is_tests_query_requested(self, **kwargs) -> bool:

--- a/cibyl/sources/zuul/queries/builds.py
+++ b/cibyl/sources/zuul/queries/builds.py
@@ -56,6 +56,10 @@ def perform_builds_query(job, **kwargs):
     if 'last_build' in kwargs:
         builds.with_last_build_only()
 
+    if 'last_completed_build' in kwargs:
+        builds.with_status('SUCCESS')
+        builds.with_last_build_only()
+
     result += builds.get()
 
     return result

--- a/cibyl/sources/zuul/queries/builds.py
+++ b/cibyl/sources/zuul/queries/builds.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.models.ci.zuul.test import TestStatus
 
 
 def perform_builds_query(job, **kwargs):
@@ -57,7 +58,7 @@ def perform_builds_query(job, **kwargs):
         builds.with_last_build_only()
 
     if 'last_completed_build' in kwargs:
-        builds.with_status('SUCCESS')
+        builds.with_status(TestStatus.SUCCESS)
         builds.with_last_build_only()
 
     result += builds.get()

--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -298,8 +298,13 @@ class BuildsRequest(Request):
         """
 
         def test(build):
+            result = build.result
+
+            if not result:
+                return False
+
             return any(
-                matches_regex(patt, build.result) for patt in pattern
+                matches_regex(patt, result) for patt in pattern
             )
 
         self._filters.append(test)
@@ -391,9 +396,9 @@ class TestsRequest(Request):
         def test(response):
             return any(
                 matches_regex(patt, response.name) for patt in pattern
-                ) or any(
+            ) or any(
                 matches_regex(patt, response.class_name) for patt in pattern
-                )
+            )
 
         self._filters.append(test)
         return self


### PR DESCRIPTION
On this PR:
- Added '--last-completed-build' below the job model as an argument for all sources.
- Implemented that CLI on the Zuul source.

The argument just acts as a macro for: '--build-status SUCCESS --last-build'.

Also, fixed a bug where '--build-status' crashed if a build was currently running.