### PR TITLE
Introducing Zuul.d as a backend to the Zuul source

### DIFF
--- a/kernel/tools/fs.py
+++ b/kernel/tools/fs.py
@@ -148,3 +148,41 @@ class File(FSPath):
     @overrides
     def exists(self) -> bool:
         return self.as_path().is_file()
+
+    def create(self) -> None:
+        """Creates the file at this path.
+        """
+        self.write('')
+
+    def delete(self) -> None:
+        """Deletes the file at this path. Will do nothing if the file does
+        not exist.
+        """
+        try:
+            self.as_path().unlink()
+        except FileNotFoundError:
+            # python 3.6 does not support the missing_ok parameter for unlink,
+            # so we swallow the error here to keep the same functionality
+            pass
+
+    def append(self, text: str) -> None:
+        """Appends some text at the end of the file.
+        :param text: Text to append.
+        """
+        self._write(text, 'a')
+
+    def write(self, text: str) -> None:
+        """Overwrites contents of the file with the given text.
+        :param text: Text to write.
+        """
+        self._write(text, 'w')
+
+    def _write(self, text: str, mode: str) -> None:
+        """Writes some text into the file. This makes no checks to verify
+        that the file exists and is accessible beforehand, it is up to the
+        caller to ensure this.
+        :param text: Text to write.
+        :param mode: Mode to write on, just like in builtin 'open'.
+        """
+        with open(self, mode) as buffer:
+            buffer.write(text)

--- a/tests/cibyl/e2e/test_jenkins.py
+++ b/tests/cibyl/e2e/test_jenkins.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 import sys
+from tempfile import NamedTemporaryFile
 
 from cibyl.cli.main import main
 from cibyl.utils.colors import Colors
@@ -69,6 +70,29 @@ class TestJenkins(EndToEndTest):
             expected.add('Total jobs found in query: 3', 2)
 
             self.assertIn(expected.build(), self.stdout)
+
+    def test_get_write_output_file(self):
+        """Checks that output is written to file.
+        """
+        with JenkinsContainer() as jenkins:
+            jenkins.add_job('test_1')
+            jenkins.add_job('test_2')
+
+            with NamedTemporaryFile() as out_file:
+                sys.argv = [
+                    'cibyl',
+                    '--config', 'tests/cibyl/e2e/data/configs/jenkins.yaml',
+                    '-o', out_file.name,
+                    '-f', 'text',
+                    '-vv', 'query',
+                    '--jobs'
+                ]
+
+                main()
+                with open(out_file.name) as f:
+                    output = f.read()
+
+                self.assertIn('Total jobs found in query: 2', output)
 
 
 class TestJenkinsCore(EndToEndTest):


### PR DESCRIPTION
Prototype for a solution that will make Zuul.d a content provider to the Zuul source instead of being a source of its own. This will allow us to reuse all the tools that were built for Zuul on this source.

Code on this PR is pretty rough. My intention was just getting something out there to see if the idea could be performed. From the PR I will build smaller ones that increasingly implement the functionality.

Feedback is welcome.