### PR TITLE
Introducing Git backend for Zuul.D

### DIFF
--- a/cibyl/_data/schemas/zuuld.json
+++ b/cibyl/_data/schemas/zuuld.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "job": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "parent": {
+            "type": "string"
+          },
+          "branches": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "additionalItems": false
+              }
+            ]
+          },
+          "vars": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": true
+      }
+    },
+    "additionalProperties": true
+  },
+  "additionalItems": false
+}

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -29,7 +29,7 @@ from cibyl.exceptions.config import SchemaError
 from cibyl.models.ci.system_factory import SystemType
 from cibyl.utils import yaml
 from kernel.tools.files import get_first_available_file, is_file_available
-from kernel.tools.fs import File, cd_context_manager
+from kernel.tools.fs import File, cd
 from kernel.tools.json import Draft7ValidatorFactory
 from kernel.tools.net import DownloadError, download_file
 
@@ -153,7 +153,7 @@ class AppConfig(Config):
             raise conf_exc.MissingSystemSources(system_name)
 
     def _verify_by_schema(self):
-        with cd_context_manager(pwd[0]):
+        with cd(pwd[0]):
             validators = Draft7ValidatorFactory()
             validator = validators.from_file(self._schema)
 

--- a/cibyl/sources/zuuld/__init__.py
+++ b/cibyl/sources/zuuld/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/sources/zuuld/backends/__init__.py
+++ b/cibyl/sources/zuuld/backends/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/sources/zuuld/backends/abc.py
+++ b/cibyl/sources/zuuld/backends/abc.py
@@ -1,0 +1,36 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from abc import ABC, abstractmethod
+from typing import Generic, Iterable, TypeVar
+
+from cibyl.sources.zuuld.models.job import Job
+from cibyl.sources.zuuld.specs.abc import SCMSpec
+
+T = TypeVar('T', bound=SCMSpec)
+
+
+class ZuulDBackend(Generic[T]):
+    class Get(ABC):
+        @abstractmethod
+        def jobs(self, spec: T) -> Iterable[Job]:
+            raise NotImplementedError
+
+    def __init__(self, get: Get):
+        self._get = get
+
+    @property
+    def get(self) -> Get:
+        return self._get

--- a/cibyl/sources/zuuld/backends/abc.py
+++ b/cibyl/sources/zuuld/backends/abc.py
@@ -20,17 +20,48 @@ from cibyl.sources.zuuld.models.job import Job
 from cibyl.sources.zuuld.specs.abc import SCMSpec
 
 T = TypeVar('T', bound=SCMSpec)
+"""Type for the kind of spec used by backend."""
 
 
 class ZuulDBackend(Generic[T]):
+    """Base class for APIs that allow Cibyl to interact with Zuul.D providers.
+
+    A Zuul.D provider is considered to be any storage that holds Zuul
+    definition files in it. These are the files that describe many of the
+    elements that take part on a Zuul instance, such as jobs or pipelines.
+
+    An example of a Zuul.D provider may be a Git or SVN repository.
+    """
+
     class Get(ABC):
+        """Base class for APIs that focus on read operations.
+        """
+
         @abstractmethod
         def jobs(self, spec: T) -> Iterable[Job]:
+            """Retrieves all jobs defined under the spec.
+
+            :param spec:
+                Describes the repository and location within where the
+                Zuul.D files are located at.
+            :return:
+                A transcription of all job objects found under the files
+                declared at the spec.
+            """
             raise NotImplementedError
 
     def __init__(self, get: Get):
+        """Constructor.
+
+        :param get: The backend that will support read operations.
+        """
         self._get = get
 
     @property
     def get(self) -> Get:
+        """
+        :return:
+            Interface for performing read operations against Zuul.D
+            providers.
+        """
         return self._get

--- a/cibyl/sources/zuuld/backends/git.py
+++ b/cibyl/sources/zuuld/backends/git.py
@@ -1,0 +1,71 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from overrides import overrides
+
+from cibyl.sources.zuuld.backends.abc import T, ZuulDBackend
+from cibyl.sources.zuuld.errors import IllegibleData
+from cibyl.sources.zuuld.models.job import Job
+from cibyl.sources.zuuld.specs.git import GitSpec
+from cibyl.sources.zuuld.tools.yaml import YAMLReaderFactory, YAMLSearch
+from kernel.scm.git.tools.cloning import RepositoryFactory
+
+
+class GitBackend(ZuulDBackend[GitSpec]):
+    class Get(ZuulDBackend.Get):
+        @dataclass
+        class Tools:
+            repositories: RepositoryFactory = field(
+                default_factory=lambda *_: RepositoryFactory()
+            )
+            files: YAMLSearch = field(
+                default_factory=lambda *_: YAMLSearch()
+            )
+            readers: YAMLReaderFactory = field(
+                default_factory=lambda *_: YAMLReaderFactory()
+            )
+
+        def __init__(self, tools: Optional[Tools] = None):
+            if tools is None:
+                tools = GitBackend.Get.Tools()
+
+            self._tools = tools
+
+        @property
+        def tools(self) -> Tools:
+            return self._tools
+
+        @overrides
+        def jobs(self, spec: T) -> Iterable[Job]:
+            repo = self.tools.repositories.from_remote(url=spec.remote)
+            directory = repo.workspace.cd(spec.directory)
+
+            result = []
+
+            for file in self.tools.files.search(directory):
+                reader = self.tools.readers.from_file(file)
+
+                try:
+                    result += reader.jobs()
+                except IllegibleData:
+                    continue
+
+            return result
+
+    def __init__(self):
+        super().__init__(get=GitBackend.Get())

--- a/cibyl/sources/zuuld/backends/git.py
+++ b/cibyl/sources/zuuld/backends/git.py
@@ -27,20 +27,47 @@ from kernel.scm.git.tools.cloning import RepositoryFactory
 
 
 class GitBackend(ZuulDBackend[GitSpec]):
+    """Implementation of a Zuul.D backend that allows interaction with Git
+    repositories through Git's CLI.
+
+    Bear in mind that this backend will require cloning of repositories and,
+    as such, will need a location on the filesystem to hold that data. An
+    effort is made to reduce the amount of cloning performed, but it is
+    unavoidable.
+
+    Additionally, the backend does not take care of authentication
+    operations. Accessing a repository through SSH is up to the user to have
+    prepared (like loading the keys...) before this is used.
+    """
+
     class Get(ZuulDBackend.Get):
+        """Clones specs and reads the information within.
+        """
+
         @dataclass
         class Tools:
+            """Tools this uses to do its task.
+            """
             repositories: RepositoryFactory = field(
                 default_factory=lambda *_: RepositoryFactory()
             )
+            """Used to clone repositories and keep track of them."""
             files: YAMLSearch = field(
                 default_factory=lambda *_: YAMLSearch()
             )
+            """Used to look for Zuul.D files on the repository."""
             readers: YAMLReaderFactory = field(
                 default_factory=lambda *_: YAMLReaderFactory()
             )
+            """Used to parse the Zuul.D files into Python objects."""
 
         def __init__(self, tools: Optional[Tools] = None):
+            """Constructor.
+
+            :param tools:
+                Tools this uses to do its task.
+                'None' to let it build its own.
+            """
             if tools is None:
                 tools = GitBackend.Get.Tools()
 
@@ -48,6 +75,9 @@ class GitBackend(ZuulDBackend[GitSpec]):
 
         @property
         def tools(self) -> Tools:
+            """
+            :return: Tools this uses to do its task.
+            """
             return self._tools
 
         @overrides
@@ -68,4 +98,6 @@ class GitBackend(ZuulDBackend[GitSpec]):
             return result
 
     def __init__(self):
+        """Constructor.
+        """
         super().__init__(get=GitBackend.Get())

--- a/cibyl/sources/zuuld/backends/git.py
+++ b/cibyl/sources/zuuld/backends/git.py
@@ -14,7 +14,6 @@
 #    under the License.
 """
 import logging
-
 from dataclasses import dataclass, field
 from typing import Iterable, Optional
 

--- a/cibyl/sources/zuuld/errors.py
+++ b/cibyl/sources/zuuld/errors.py
@@ -13,9 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions.source import SourceException
 
 
-class ZuulDError(Exception):
+class ZuulDError(SourceException):
     """Generic error occurring on the Zuul.d API.
     """
 

--- a/cibyl/sources/zuuld/errors.py
+++ b/cibyl/sources/zuuld/errors.py
@@ -1,0 +1,31 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+class ZuulDError(Exception):
+    """Generic error occurring on the Zuul.d API.
+    """
+
+
+class InvalidURL(ZuulDError):
+    """A URL does not conform to its expected structure.
+    """
+
+
+class IllegibleData(ZuulDError):
+    """Some data read by the API does not conform to the structure expected
+    by it.
+    """

--- a/cibyl/sources/zuuld/models/__init__.py
+++ b/cibyl/sources/zuuld/models/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/sources/zuuld/models/job.py
+++ b/cibyl/sources/zuuld/models/job.py
@@ -19,7 +19,13 @@ from typing import Any, Dict, Iterable, Optional
 
 @dataclass
 class Job:
+    """Transcription of a job object from a Zuul.D file.
+    """
     name: str
+    """Name of the job."""
     parent: Optional[str] = field(default_factory=lambda: None)
+    """Name of the parent job for this one."""
     branches: Iterable[str] = field(default_factory=lambda: [])
+    """Branches the job triggers at."""
     vars: Dict[str, Any] = field(default_factory=lambda: {})
+    """Collection of variables that specialize the job."""

--- a/cibyl/sources/zuuld/models/job.py
+++ b/cibyl/sources/zuuld/models/job.py
@@ -1,0 +1,25 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Optional
+
+
+@dataclass
+class Job:
+    name: str
+    parent: Optional[str] = field(default_factory=lambda: None)
+    branches: Iterable[str] = field(default_factory=lambda: [])
+    vars: Dict[str, Any] = field(default_factory=lambda: {})

--- a/cibyl/sources/zuuld/specs/__init__.py
+++ b/cibyl/sources/zuuld/specs/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/sources/zuuld/specs/abc.py
+++ b/cibyl/sources/zuuld/specs/abc.py
@@ -21,5 +21,11 @@ from kernel.tools.urls import URL
 
 @dataclass
 class SCMSpec:
+    """Defines location of Zuul.D files for a generic SCM.
+    """
     remote: URL
-    directory: Path = field(default_factory=lambda: Path('.'))
+    """Address to the repository that hosts the files."""
+    directory: Path = field(default_factory=lambda: Path('zuul.d/'))
+    """Path, relative to the repository's root, to the directory where the 
+    Zuul.D files are stored in.
+    """

--- a/cibyl/sources/zuuld/specs/abc.py
+++ b/cibyl/sources/zuuld/specs/abc.py
@@ -1,0 +1,25 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kernel.tools.urls import URL
+
+
+@dataclass
+class SCMSpec:
+    remote: URL
+    directory: Path = field(default_factory=lambda: Path('.'))

--- a/cibyl/sources/zuuld/specs/abc.py
+++ b/cibyl/sources/zuuld/specs/abc.py
@@ -26,6 +26,9 @@ class SCMSpec:
     remote: URL
     """Address to the repository that hosts the files."""
     directory: Path = field(default_factory=lambda: Path('zuul.d/'))
-    """Path, relative to the repository's root, to the directory where the 
+    """Path, relative to the repository's root, to the directory where the
     Zuul.D files are stored in.
     """
+
+    def __str__(self):
+        return f"[Remote: '{self.remote}', Directory: '{self.directory}']"

--- a/cibyl/sources/zuuld/specs/git.py
+++ b/cibyl/sources/zuuld/specs/git.py
@@ -22,6 +22,13 @@ from kernel.tools.urls import is_git
 
 @dataclass
 class GitSpec(SCMSpec):
+    """Defines location of Zuul.D files inside a Git repository.
+
+    This class provides some additional checks over its generic counterpart:
+        - For 'remote': It checks that the URL is a valid Git URL. Raises
+        :class:`InvalidURL` if not.
+    """
+
     def __post_init__(self):
         if not is_git(self.remote):
             raise InvalidURL(f"Not a Git URL: '{self.remote}'")

--- a/cibyl/sources/zuuld/specs/git.py
+++ b/cibyl/sources/zuuld/specs/git.py
@@ -1,0 +1,27 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from dataclasses import dataclass
+
+from cibyl.sources.zuuld.errors import InvalidURL
+from cibyl.sources.zuuld.specs.abc import SCMSpec
+from kernel.tools.urls import is_git
+
+
+@dataclass
+class GitSpec(SCMSpec):
+    def __post_init__(self):
+        if not is_git(self.remote):
+            raise InvalidURL(f"Not a Git URL: '{self.remote}'")

--- a/cibyl/sources/zuuld/tools/__init__.py
+++ b/cibyl/sources/zuuld/tools/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -26,9 +26,18 @@ LOG = logging.getLogger(__name__)
 
 
 class ZuulDFile(YAMLFile):
+    """Representation of a YAML file that meets the Zuul.D schema.
+    """
     SCHEMA = File('_data/schemas/zuuld.json')
+    """Location of the Zuul.D schema."""
 
     def __init__(self, file: File, tools: Optional[YAMLFile.Tools] = None):
+        """Constructor.
+
+        :param file: File to test against the Zuul.D schema.
+        :param tools: Tools this uses to do its task.
+        :raises YAMLError: If the file does not meet the schema.
+        """
         super().__init__(
             file=file,
             schema=ZuulDFile.SCHEMA,
@@ -37,30 +46,67 @@ class ZuulDFile(YAMLFile):
 
 
 class ZuulDFileFactory:
+    """Factory for :class:`ZuulDFile`.
+    """
+
     def from_file(self, file: File) -> ZuulDFile:
+        """Builds a new Zuul.D file from a generic one.
+
+        :param file: File that will be tested to see if it is a Zuul.D file.
+        :return: The given file, this time caster to a Zuul.D one.
+        :raises YAMLError: If the file does not meet the Zuul.D criteria.
+        """
         return ZuulDFile(file)
 
 
 class YAMLReader:
+    """Parses the contents of a Zuul.D file.
+    """
+
     class DataExtractor:
+        """Utility class used to extract YAML data from a Zuul.D file.
+        """
+
         def __init__(self, file: ZuulDFile):
+            """Constructor.
+
+            :param file: The file to get the data from.
+            """
             self._file = file
 
         @property
         def file(self) -> ZuulDFile:
+            """
+            :return: File this class is extracting data from.
+            """
             return self._file
 
         def jobs(self) -> YAMLArray:
+            """
+            :return: All 'job' entries found on the file.
+            """
             return [entry['job'] for entry in self.file.data if 'job' in entry]
 
     def __init__(self, file: ZuulDFile):
+        """Constructor.
+
+        :param file: The file to parse.
+        """
         self._data = YAMLReader.DataExtractor(file)
 
     @property
     def file(self) -> ZuulDFile:
+        """
+        :return: The file this class is parsing.
+        """
         return self._data.file
 
     def jobs(self) -> Iterable[Job]:
+        """Parses all job entries on the file and returns a python
+        representation for each of them.
+
+        :return: Model for each job entry on the file.
+        """
         result = []
 
         for job in self._data.jobs():
@@ -92,11 +138,22 @@ class YAMLReaderFactory:
     """
 
     def from_file(self, file: ZuulDFile) -> YAMLReader:
+        """Builds a new reader from a Zuul.D file.
+
+        :param file: The Zuul.D file.
+        :return: The reader instance.
+        """
         return YAMLReader(file)
 
 
 class YAMLSearch:
-    """Recursively looks for YAML files on a directory.
+    """Recursively looks for Zuul.D YAML files on a directory.
+
+    The class crawls first through a directory in search of generic YAML
+    files to test. Then, it checks each one in order to look for those
+    that can be considered Zuul.D compliant and finally returns those.
+
+    A Zuul.D compliant YAML file are those files that meet the Zuul.D schema.
     """
     DEFAULT_YAML_EXTENSIONS = ('.yml', '.yaml')
     """Default file extensions that identify YAML files."""
@@ -112,6 +169,7 @@ class YAMLSearch:
         files: ZuulDFileFactory = field(
             default_factory=lambda *_: ZuulDFileFactory()
         )
+        """Used to go from a generic YAML file to a Zuul.D compliant one."""
 
     def __init__(
         self,
@@ -122,7 +180,11 @@ class YAMLSearch:
 
         :param extensions:
             File extensions that identify YAML files.
-            'None' to use the default set: YAMLReader.DEFAULT_YAML_EXTENSIONS
+            These point to all files on a directory that are to be
+            checked for Zuul.D contents.
+            Consequently, files identified by these extensions may, or not, be
+            Zuul.D compliant.
+            'None' to use the default set: YAMLReader.DEFAULT_YAML_EXTENSIONS.
         :param tools:
             Tools used by the class to do its job.
             'None' to let this build its own.
@@ -139,23 +201,22 @@ class YAMLSearch:
     @property
     def extensions(self) -> Iterable[str]:
         """
-        :return: File extensions the class look for.
+        :return: File extensions the class looks for.
         """
         return self._extensions
 
     @property
     def tools(self) -> Tools:
         """
-        :return: Tools used by this to do its task.
+        :return: Tools used by the class to do its job.
         """
         return self._tools
 
     def search(self, path: Dir) -> Iterable[ZuulDFile]:
-        """Recursively searches the directory for all YAML files contained
-        within.
+        """Recursively searches the directory for all Zuul.D YAML files on it.
 
         :param path: Directory to look in.
-        :return: A handle to all retrieved files.
+        :return: A handle to all found files.
         """
         result = []
 
@@ -172,7 +233,12 @@ class YAMLSearch:
 
         return result
 
-    def _search_for_yamls_at(self, path: Dir):
+    def _search_for_yamls_at(self, path: Dir) -> Iterable[File]:
+        """Recursively looks for all YAML files on a directory.
+
+        :param path: Directory to look in.
+        :return: A handle to all found files.
+        """
         search = self.tools.searches.from_root(path)
         search.with_recursion()
 

--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -1,0 +1,153 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from cached_property import cached_property
+
+from cibyl import __path__ as pwd
+from cibyl.sources.zuuld.errors import IllegibleData
+from cibyl.sources.zuuld.models.job import Job
+from kernel.tools.files import FileSearchFactory
+from kernel.tools.fs import Dir, File, cd_context_manager
+from kernel.tools.json import Draft7ValidatorFactory, JSONValidatorFactory
+from kernel.tools.yaml import YAML, StandardYAMLParser, YAMLArray, YAMLParser
+
+
+class YAMLReader:
+    DEFAULT_SCHEMA = File('_data/schemas/zuuld.json')
+
+    @dataclass
+    class Tools:
+        parser: YAMLParser = field(
+            default_factory=lambda *_: StandardYAMLParser()
+        )
+        validators: JSONValidatorFactory = field(
+            default_factory=lambda *_: Draft7ValidatorFactory()
+        )
+
+    def __init__(
+        self,
+        file: File,
+        schema: Optional[File] = None,
+        tools: Optional[Tools] = None
+    ):
+        if schema is None:
+            schema = YAMLReader.DEFAULT_SCHEMA
+
+        if tools is None:
+            tools = YAMLReader.Tools()
+
+        self._file = file
+        self._schema = schema
+        self._tools = tools
+
+    @cached_property
+    def data(self) -> YAML:
+        data = self.tools.parser.as_yaml(self.file.read())
+
+        with cd_context_manager(pwd[0]):
+            validator = self.tools.validators.from_file(self.schema)
+
+            if not validator.is_valid(data):
+                raise IllegibleData()
+
+        return data
+
+    @property
+    def file(self) -> File:
+        return self._file
+
+    @property
+    def schema(self) -> File:
+        return self._schema
+
+    @property
+    def tools(self) -> Tools:
+        return self._tools
+
+    def jobs(self) -> Iterable[Job]:
+        def jobs() -> YAMLArray:
+            return [entry['job'] for entry in self.data if 'job' in entry]
+
+        result = []
+
+        for job in jobs():
+            model = Job(
+                name=job['name']
+            )
+
+            if 'parent' in job:
+                model.parent = job['parent']
+
+            if 'branches' in job:
+                branches = job['branches']
+
+                if isinstance(branches, str):
+                    branches = [branches]
+
+                model.branches = branches
+
+            if 'vars' in job:
+                model.vars = job['vars']
+
+            result.append(model)
+
+        return result
+
+
+class YAMLReaderFactory:
+    """Factory for :class:`YAMLReader`.
+    """
+
+    def from_file(self, file: File) -> YAMLReader:
+        return YAMLReader(file)
+
+
+class YAMLSearch:
+    DEFAULT_YAML_EXTENSIONS = ('.yml', '.yaml')
+
+    @dataclass
+    class Tools:
+        files: FileSearchFactory = field(
+            default_factory=lambda *_: FileSearchFactory()
+        )
+
+    def __init__(self, tools: Optional[Tools] = None):
+        if tools is None:
+            tools = YAMLSearch.Tools()
+
+        self._tools = tools
+
+    @property
+    def tools(self) -> Tools:
+        return self._tools
+
+    def search(
+        self,
+        path: Dir,
+        extensions: Optional[Iterable[str]] = None
+    ) -> Iterable[File]:
+        if extensions is None:
+            extensions = YAMLSearch.DEFAULT_YAML_EXTENSIONS
+
+        search = self.tools.files.from_root(path)
+        search.with_recursion()
+
+        for ext in extensions:
+            search.with_extension(ext)
+
+        return [File(path) for path in search.get()]

--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -126,28 +126,33 @@ class YAMLSearch:
             default_factory=lambda *_: FileSearchFactory()
         )
 
-    def __init__(self, tools: Optional[Tools] = None):
+    def __init__(
+        self,
+        extensions: Optional[Iterable[str]] = None,
+        tools: Optional[Tools] = None
+    ):
+        if extensions is None:
+            extensions = YAMLSearch.DEFAULT_YAML_EXTENSIONS
+
         if tools is None:
             tools = YAMLSearch.Tools()
 
+        self._extensions = extensions
         self._tools = tools
+
+    @property
+    def extensions(self) -> Iterable[str]:
+        return self._extensions
 
     @property
     def tools(self) -> Tools:
         return self._tools
 
-    def search(
-        self,
-        path: Dir,
-        extensions: Optional[Iterable[str]] = None
-    ) -> Iterable[File]:
-        if extensions is None:
-            extensions = YAMLSearch.DEFAULT_YAML_EXTENSIONS
-
+    def search(self, path: Dir) -> Iterable[File]:
         search = self.tools.files.from_root(path)
         search.with_recursion()
 
-        for ext in extensions:
+        for ext in self.extensions:
             search.with_extension(ext)
 
         return [File(path) for path in search.get()]

--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -26,6 +26,8 @@ from kernel.tools.fs import Dir, File, cd_context_manager
 from kernel.tools.json import Draft7ValidatorFactory, JSONValidatorFactory
 from kernel.tools.yaml import YAML, StandardYAMLParser, YAMLArray, YAMLParser
 
+YAMLFile = File
+
 
 class YAMLReader:
     DEFAULT_SCHEMA = File('_data/schemas/zuuld.json')
@@ -114,23 +116,43 @@ class YAMLReaderFactory:
     """
 
     def from_file(self, file: File) -> YAMLReader:
+        """Builds a new reader for the given file.
+
+        :param file: The YAML file to handle.
+        :return: The new instance.
+        """
         return YAMLReader(file)
 
 
 class YAMLSearch:
+    """Recursively looks for YAML files on a directory.
+    """
     DEFAULT_YAML_EXTENSIONS = ('.yml', '.yaml')
+    """Default file extensions that identify YAML files."""
 
     @dataclass
     class Tools:
+        """Tools used by the class to do its job.
+        """
         files: FileSearchFactory = field(
             default_factory=lambda *_: FileSearchFactory()
         )
+        """Used to perform the search for interesting files."""
 
     def __init__(
         self,
         extensions: Optional[Iterable[str]] = None,
         tools: Optional[Tools] = None
     ):
+        """Constructor.
+
+        :param extensions:
+            File extensions that identify YAML files.
+            'None' to use the default set: YAMLReader.DEFAULT_YAML_EXTENSIONS
+        :param tools:
+            Tools used by the class to do its job.
+            'None' to let this build its own.
+        """
         if extensions is None:
             extensions = YAMLSearch.DEFAULT_YAML_EXTENSIONS
 
@@ -142,17 +164,29 @@ class YAMLSearch:
 
     @property
     def extensions(self) -> Iterable[str]:
+        """
+        :return: File extensions the class look for.
+        """
         return self._extensions
 
     @property
     def tools(self) -> Tools:
+        """
+        :return: Tools used by this to do its task.
+        """
         return self._tools
 
-    def search(self, path: Dir) -> Iterable[File]:
+    def search(self, path: Dir) -> Iterable[YAMLFile]:
+        """Recursively searches the directory for all YAML files contained
+        within.
+
+        :param path: Directory to look in.
+        :return: A handle to all retrieved files.
+        """
         search = self.tools.files.from_root(path)
         search.with_recursion()
 
         for ext in self.extensions:
             search.with_extension(ext)
 
-        return [File(path) for path in search.get()]
+        return [YAMLFile(path) for path in search.get()]

--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -18,11 +18,10 @@ from typing import Iterable, Optional
 
 from cached_property import cached_property
 
-from cibyl import __path__ as pwd
 from cibyl.sources.zuuld.errors import IllegibleData
 from cibyl.sources.zuuld.models.job import Job
 from kernel.tools.files import FileSearchFactory
-from kernel.tools.fs import Dir, File, cd_context_manager
+from kernel.tools.fs import Dir, File, KnownDirs, cd
 from kernel.tools.json import Draft7ValidatorFactory, JSONValidatorFactory
 from kernel.tools.yaml import YAML, StandardYAMLParser, YAMLArray, YAMLParser
 
@@ -61,7 +60,7 @@ class YAMLReader:
     def data(self) -> YAML:
         data = self.tools.parser.as_yaml(self.file.read())
 
-        with cd_context_manager(pwd[0]):
+        with cd(KnownDirs.DATA):
             validator = self.tools.validators.from_file(self.schema)
 
             if not validator.is_valid(data):

--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -230,6 +230,7 @@ class YAMLSearch:
                     "the Zuul.D file schema.",
                     {'find': find}
                 )
+                continue
 
         return result
 

--- a/kernel/tools/fs.py
+++ b/kernel/tools/fs.py
@@ -196,8 +196,8 @@ class File(FSPath):
 
 class KnownDirs:
     """Preset of directories used by Cibyl."""
-    DATA = Dir(pwd[0])
-    """Directory where Cibyl's resources are found in."""
+    CIBYL = Dir(pwd[0])
+    """Cibyl's main module directory."""
 
 
 @contextmanager

--- a/kernel/tools/fs.py
+++ b/kernel/tools/fs.py
@@ -22,21 +22,10 @@ from typing import Generator, Union
 
 from overrides import overrides
 
+from cibyl import __path__ as pwd
 from kernel.tools.paths import Preprocessor
 
 RawPath = Union[bytes, str, PathLike, Path]
-
-
-@contextmanager
-def cd_context_manager(path: RawPath) -> Generator:
-    """Simple context manager that changes the working directory and restores
-    the previous one on exit"""
-    old_dir = getcwd()
-    chdir(path)
-    try:
-        yield
-    finally:
-        chdir(old_dir)
 
 
 class FSPath(str, ABC):
@@ -203,3 +192,22 @@ class File(FSPath):
         """
         with self.as_path().open('r', encoding=encoding) as file:
             return file.read()
+
+
+class KnownDirs:
+    """Preset of directories used by Cibyl."""
+    DATA = Dir(pwd[0])
+    """Directory where Cibyl's resources are found in."""
+
+
+@contextmanager
+def cd(path: RawPath) -> Generator:
+    """Simple context manager that changes the working directory and restores
+    the previous one on exit.
+    """
+    old_dir = getcwd()
+    chdir(path)
+    try:
+        yield
+    finally:
+        chdir(old_dir)

--- a/kernel/tools/yaml.py
+++ b/kernel/tools/yaml.py
@@ -121,11 +121,3 @@ class YAMLFile:
     @property
     def tools(self) -> Tools:
         return self._tools
-
-
-class YAMLFileFactory:
-    """Factory for :class:`YAMLFile`.
-    """
-
-    def from_file(self, file: File, schema: Optional[File] = None):
-        return YAMLFile(file, schema)

--- a/kernel/tools/yaml.py
+++ b/kernel/tools/yaml.py
@@ -68,14 +68,21 @@ class StandardYAMLParser(YAMLParser):
 
 
 class YAMLFile:
+    """Representation of YAML-like file.
+    """
+
     @dataclass
     class Tools:
+        """Tools this uses to do its task.
+        """
         parser: YAMLParser = field(
             default_factory=lambda *_: StandardYAMLParser()
         )
+        """Used to translate the data in the file into python-readable."""
         validators: JSONValidatorFactory = field(
             default_factory=lambda *_: Draft7ValidatorFactory()
         )
+        """Used to face the data in the file against an schema."""
 
     def __init__(
         self,
@@ -83,6 +90,20 @@ class YAMLFile:
         schema: Optional[File] = None,
         tools: Optional[Tools] = None
     ):
+        """Constructor.
+
+        :param file:
+            The YAML file to have this class wrap around.
+        :param schema:
+            Schema that the data in the file must meet.
+            'None' to ignore.
+        :param tools:
+            Selection of tools this uses to do its task.
+            'None' to have this build its own.
+        :raises YAMLError:
+            If the data is not in YAML format.
+            If the data does not meet the schema.
+        """
         if tools is None:
             tools = YAMLFile.Tools()
 
@@ -93,6 +114,12 @@ class YAMLFile:
         self._validate()
 
     def _validate(self):
+        """Checks that the file meets the given schema. Throws an error if it
+        does not, returns if it does. In case no schema was provided, this does
+        nothing.
+
+        :raises YAMLError: If the data does not meet the schema.
+        """
         if self.schema is None:
             return
 
@@ -108,16 +135,28 @@ class YAMLFile:
 
     @cached_property
     def data(self) -> YAML:
+        """
+        :return: Raw data found within the file, verified against the schema.
+        """
         return self.tools.parser.as_yaml(self.file.read())
 
     @property
     def file(self) -> File:
+        """
+        :return: The YAML file this is handling.
+        """
         return self._file
 
     @property
     def schema(self) -> Optional[File]:
+        """
+        :return: The schema met by the file. 'None' if this was skipped.
+        """
         return self._schema
 
     @property
     def tools(self) -> Tools:
+        """
+        :return: Tools this uses to do its task.
+        """
         return self._tools

--- a/tests/cibyl/intr/sources/zuuld/__init__.py
+++ b/tests/cibyl/intr/sources/zuuld/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/intr/sources/zuuld/specs/__init__.py
+++ b/tests/cibyl/intr/sources/zuuld/specs/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/intr/sources/zuuld/specs/git.py
+++ b/tests/cibyl/intr/sources/zuuld/specs/git.py
@@ -1,0 +1,34 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.sources.zuuld.errors import InvalidURL
+from cibyl.sources.zuuld.specs.git import GitSpec
+from kernel.tools.urls import URL
+
+
+class TestGitSpec(TestCase):
+    """Tests for :class:`GitSpec`.
+    """
+
+    def test_error_if_not_git_url(self):
+        """Checks that an error is raised if the remote URL is not a Git
+        URL.
+        """
+        url = URL('http://localhost:8080')
+
+        with self.assertRaises(InvalidURL):
+            GitSpec(remote=url)

--- a/tests/cibyl/intr/sources/zuuld/tools/__init__.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
@@ -1,0 +1,44 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+from unittest import TestCase
+
+from cibyl.sources.zuuld.tools.yaml import YAMLSearch
+from kernel.tools.fs import Dir
+
+
+class TestYAMLSearch(TestCase):
+    """Tests for :class:`YAMLSearch`.
+    """
+
+    def test_finds_files(self):
+        """Checks that the class is able to find the desired files.
+        """
+        with TemporaryDirectory() as folder:
+            directory = Dir(folder)
+
+            subdirectory = directory.cd('subdir')
+            subdirectory.mkdir()
+
+            with NamedTemporaryFile(suffix='.yaml', dir=directory):
+                with NamedTemporaryFile(suffix='.yml', dir=subdirectory):
+                    search = YAMLSearch()
+
+                    result = list(search.search(directory))
+
+                    self.assertEqual(2, len(result))
+                    self.assertTrue(result[0].endswith('.yaml'))
+                    self.assertTrue(result[1].endswith('.yml'))

--- a/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
@@ -16,8 +16,27 @@
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
 
-from cibyl.sources.zuuld.tools.yaml import YAMLSearch
-from kernel.tools.fs import Dir
+from cibyl.sources.zuuld.tools.yaml import YAMLSearch, ZuulDFile
+from kernel.tools.fs import Dir, File
+from kernel.tools.yaml import YAMLError
+
+
+class TestZuulDFile(TestCase):
+    """Tests for :class:`ZuulDFile.`
+    """
+
+    def test_error_if_unmet_schema(self):
+        """Checks that an error is thrown if the file does not meet the
+        schema.
+        """
+        contents = 'hello_world!'
+
+        with NamedTemporaryFile('w') as file:
+            file.write(contents)
+            file.flush()
+
+            with self.assertRaises(YAMLError):
+                ZuulDFile(file=File(file))
 
 
 class TestYAMLSearch(TestCase):

--- a/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
@@ -27,18 +27,30 @@ class TestYAMLSearch(TestCase):
     def test_finds_files(self):
         """Checks that the class is able to find the desired files.
         """
+        contents = \
+            '''
+            - job:
+                name: test
+            '''
+
         with TemporaryDirectory() as folder:
             directory = Dir(folder)
 
             subdirectory = directory.cd('subdir')
             subdirectory.mkdir()
 
-            with NamedTemporaryFile(suffix='.yaml', dir=directory):
-                with NamedTemporaryFile(suffix='.yml', dir=subdirectory):
-                    search = YAMLSearch()
+            file1 = NamedTemporaryFile('w', suffix='.yaml', dir=directory)
+            file1.write(contents)
+            file1.flush()
 
-                    result = list(search.search(directory))
+            file2 = NamedTemporaryFile('w', suffix='.yml', dir=subdirectory)
+            file2.write(contents)
+            file2.flush()
 
-                    self.assertEqual(2, len(result))
-                    self.assertTrue(result[0].endswith('.yaml'))
-                    self.assertTrue(result[1].endswith('.yml'))
+            search = YAMLSearch()
+
+            result = list(search.search(directory))
+
+            self.assertEqual(2, len(result))
+            self.assertTrue(result[0].file.endswith('.yaml'))
+            self.assertTrue(result[1].file.endswith('.yml'))

--- a/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
@@ -36,7 +36,7 @@ class TestZuulDFile(TestCase):
             file.flush()
 
             with self.assertRaises(YAMLError):
-                ZuulDFile(file=File(file))
+                ZuulDFile(file=File(file.name))
 
 
 class TestYAMLSearch(TestCase):
@@ -58,18 +58,32 @@ class TestYAMLSearch(TestCase):
             subdirectory = directory.cd('subdir')
             subdirectory.mkdir()
 
-            file1 = NamedTemporaryFile('w', suffix='.yaml', dir=directory)
-            file1.write(contents)
-            file1.flush()
+            with NamedTemporaryFile(
+                mode='w',
+                delete=False,
+                suffix='.yaml',
+                dir=directory
+            ) as file1:
+                file1.write(contents)
 
-            file2 = NamedTemporaryFile('w', suffix='.yml', dir=subdirectory)
-            file2.write(contents)
-            file2.flush()
+            with NamedTemporaryFile(
+                mode='w',
+                delete=False,
+                suffix='.yml',
+                dir=subdirectory
+            ) as file2:
+                file2.write(contents)
 
             search = YAMLSearch()
 
             result = list(search.search(directory))
 
             self.assertEqual(2, len(result))
-            self.assertTrue(result[0].file.endswith('.yaml'))
-            self.assertTrue(result[1].file.endswith('.yml'))
+
+            self.assertTrue(
+                any(find.file.endswith('.yaml') for find in result)
+            )
+
+            self.assertTrue(
+                any(find.file.endswith('.yml') for find in result)
+            )

--- a/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
 
 from cibyl.sources.zuuld.tools.yaml import YAMLSearch

--- a/tests/cibyl/unit/sources/zuuld/__init__.py
+++ b/tests/cibyl/unit/sources/zuuld/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/unit/sources/zuuld/backends/__init__.py
+++ b/tests/cibyl/unit/sources/zuuld/backends/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/unit/sources/zuuld/backends/test_git.py
+++ b/tests/cibyl/unit/sources/zuuld/backends/test_git.py
@@ -1,0 +1,122 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.sources.zuuld.backends.git import GitBackend
+from cibyl.sources.zuuld.errors import IllegibleData
+
+
+class TestGitBackend(TestCase):
+    """Tests for :class:`GitBackend`.
+    """
+
+    def test_reads_jobs(self):
+        spec = Mock()
+        spec.remote = Mock()
+        spec.directory = Mock()
+
+        directory = Mock()
+        expected = [Mock(), Mock()]
+
+        repo = Mock()
+        repo.workspace = Mock()
+        repo.workspace.cd = Mock()
+        repo.workspace.cd.return_value = directory
+
+        repositories = Mock()
+        repositories.from_remote = Mock()
+        repositories.from_remote.return_value = repo
+
+        files = Mock()
+        files.search = Mock()
+        files.search.return_value = [Mock()]
+
+        reader = Mock()
+        reader.jobs = Mock()
+        reader.jobs.return_value = expected
+
+        readers = Mock()
+        readers.from_file = Mock()
+        readers.from_file.return_value = reader
+
+        tools = Mock()
+        tools.repositories = repositories
+        tools.files = files
+        tools.readers = readers
+
+        git = GitBackend.Get(
+            tools=tools
+        )
+
+        result = git.jobs(spec)
+
+        self.assertEqual(expected, result)
+
+        repositories.from_remote.assert_called_with(url=spec.remote)
+        repo.workspace.cd.assert_called_with(spec.directory)
+
+        files.search.assert_called_with(directory)
+        readers.from_file.assert_called_with(files.search.return_value[0])
+
+        reader.jobs.assert_called()
+
+    def test_ignores_on_error(self):
+        """Checks that if a file fails to be read, it is ignored.
+        """
+
+        def error():
+            raise IllegibleData()
+
+        spec = Mock()
+        spec.remote = Mock()
+        spec.directory = Mock()
+
+        directory = Mock()
+
+        repo = Mock()
+        repo.workspace = Mock()
+        repo.workspace.cd = Mock()
+        repo.workspace.cd.return_value = directory
+
+        repositories = Mock()
+        repositories.from_remote = Mock()
+        repositories.from_remote.return_value = repo
+
+        files = Mock()
+        files.search = Mock()
+        files.search.return_value = [Mock()]
+
+        reader = Mock()
+        reader.jobs = Mock()
+        reader.jobs.side_effect = lambda *_: error()
+
+        readers = Mock()
+        readers.from_file = Mock()
+        readers.from_file.return_value = reader
+
+        tools = Mock()
+        tools.repositories = repositories
+        tools.files = files
+        tools.readers = readers
+
+        git = GitBackend.Get(
+            tools=tools
+        )
+
+        result = git.jobs(spec)
+
+        self.assertEqual([], result)

--- a/tests/cibyl/unit/sources/zuuld/tools/__init__.py
+++ b/tests/cibyl/unit/sources/zuuld/tools/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/unit/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/unit/sources/zuuld/tools/test_yaml.py
@@ -16,7 +16,64 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, call
 
-from cibyl.sources.zuuld.tools.yaml import YAMLSearch
+from cibyl.sources.zuuld.models.job import Job
+from cibyl.sources.zuuld.tools.yaml import YAMLReader, YAMLSearch
+
+
+class TestYAMLReader(TestCase):
+    """Tests for :class:`YAMLReader`.
+    """
+
+    def test_parses_jobs(self):
+        """Checks that the reader is capable of forming job models from the
+        data in the file.
+        """
+        data = [
+            {
+                'job': {
+                    'name': 'job1',
+                    'branches': 'master'
+                }
+            },
+            {
+                'job': {
+                    'name': 'job2',
+                    'parent': 'job1',
+                    'branches': [
+                        'main',
+                        'devel'
+                    ],
+                    'vars': {
+                        'test': 'var'
+                    }
+                }
+            }
+        ]
+
+        file = Mock()
+        file.data = data
+
+        reader = YAMLReader(file)
+
+        result = list(reader.jobs())
+
+        self.assertEqual(
+            Job(
+                name='job1',
+                branches=['master']
+            ),
+            result[0]
+        )
+
+        self.assertEqual(
+            Job(
+                name='job2',
+                parent='job1',
+                branches=['main', 'devel'],
+                vars={'test': 'var'}
+            ),
+            result[1]
+        )
 
 
 class TestYAMLSearch(TestCase):

--- a/tests/cibyl/unit/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/unit/sources/zuuld/tools/test_yaml.py
@@ -1,0 +1,137 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock, call
+
+from cibyl.sources.zuuld.tools.yaml import YAMLSearch
+
+
+class TestYAMLSearch(TestCase):
+    """Tests for :class;`YAMLSearch`.
+    """
+
+    def test_root_is_passed(self):
+        """Checks that the given root directory is the one used for the
+        search.
+        """
+        root = Mock()
+
+        builder = Mock()
+        builder.with_recursion = Mock()
+        builder.with_extension = Mock()
+        builder.get = Mock()
+        builder.get.return_value = []
+
+        factory = Mock()
+        factory.from_root = Mock()
+        factory.from_root.return_value = builder
+
+        tools = Mock()
+        tools.files = factory
+
+        search = YAMLSearch(
+            tools=tools
+        )
+
+        search.search(path=root)
+
+        factory.from_root.assert_called_once_with(root)
+
+    def test_search_is_recursive(self):
+        """Checks that the search is requested to be recursive.
+        """
+        root = Mock()
+
+        builder = Mock()
+        builder.with_recursion = Mock()
+        builder.with_extension = Mock()
+        builder.get = Mock()
+        builder.get.return_value = []
+
+        factory = Mock()
+        factory.from_root = Mock()
+        factory.from_root.return_value = builder
+
+        tools = Mock()
+        tools.files = factory
+
+        search = YAMLSearch(
+            tools=tools
+        )
+
+        search.search(path=root)
+
+        builder.with_recursion.assert_called()
+
+    def test_search_filters_by_extensions(self):
+        """Checks that the search filters by the extensions known by the class.
+        """
+        root = Mock()
+        extensions = [Mock(), Mock()]
+
+        builder = Mock()
+        builder.with_recursion = Mock()
+        builder.with_extension = Mock()
+        builder.get = Mock()
+        builder.get.return_value = []
+
+        factory = Mock()
+        factory.from_root = Mock()
+        factory.from_root.return_value = builder
+
+        tools = Mock()
+        tools.files = factory
+
+        search = YAMLSearch(
+            extensions=extensions,
+            tools=tools
+        )
+
+        search.search(path=root)
+
+        builder.with_extension.assert_has_calls(
+            calls=[
+                call(extensions[0]),
+                call(extensions[1])
+            ]
+        )
+
+    def test_returns_files(self):
+        """Checks that the found files are returned.
+        """
+        root = Mock()
+        expected = ['path-1', 'path-2']
+
+        builder = Mock()
+        builder.with_recursion = Mock()
+        builder.with_extension = Mock()
+        builder.get = Mock()
+        builder.get.return_value = expected
+
+        factory = Mock()
+        factory.from_root = Mock()
+        factory.from_root.return_value = builder
+
+        tools = Mock()
+        tools.files = factory
+
+        search = YAMLSearch(
+            tools=tools
+        )
+
+        result = search.search(path=root)
+
+        self.assertEqual(expected, result)

--- a/tests/cibyl/unit/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/unit/sources/zuuld/tools/test_yaml.py
@@ -20,7 +20,7 @@ from cibyl.sources.zuuld.tools.yaml import YAMLSearch
 
 
 class TestYAMLSearch(TestCase):
-    """Tests for :class;`YAMLSearch`.
+    """Tests for :class:`YAMLSearch`.
     """
 
     def test_root_is_passed(self):
@@ -106,7 +106,6 @@ class TestYAMLSearch(TestCase):
         """Checks that the found files are returned.
         """
         root = Mock()
-        schema = Mock()
 
         # Reusing this mock for before and after becoming a YAMLFile.
         file1 = 'file1.yml'
@@ -129,17 +128,9 @@ class TestYAMLSearch(TestCase):
         tools.files = files
 
         yaml = YAMLSearch(
-            schema=schema,
             tools=tools
         )
 
         result = yaml.search(path=root)
 
         self.assertEqual([file1, file2], result)
-
-        files.from_file.assert_has_calls(
-            calls=[
-                call(file=file1, schema=schema),
-                call(file=file2, schema=schema)
-            ]
-        )

--- a/tests/kernel/unit/tools/test_yaml.py
+++ b/tests/kernel/unit/tools/test_yaml.py
@@ -1,0 +1,124 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from kernel.tools.yaml import YAMLError, YAMLFile
+
+
+class TestYAMLFile(TestCase):
+    """Tests for :class:`YAMLFile`.
+    """
+
+    def test_nothing_on_no_schema(self):
+        """Checks that is no schema is provided, the data is consumed without
+        question.
+        """
+        file = Mock()
+
+        tools = Mock()
+        tools.validators = Mock()
+        tools.validators.from_file = Mock()
+
+        YAMLFile(
+            file=file,
+            schema=None,
+            tools=tools
+        )
+
+        tools.validators.from_file.assert_not_called()
+
+    def test_schema_unsatisfied(self):
+        """Checks that an error is thrown if the schema is not satisfied.
+        """
+        raw = 'hello: world'
+        yaml = {'hello': 'world'}
+
+        file = Mock()
+        file.read = Mock()
+        file.read.return_value = raw
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = False
+
+        parser = Mock()
+        parser.as_yaml = Mock()
+        parser.as_yaml.return_value = yaml
+
+        tools = Mock()
+        tools.parser = parser
+        tools.validators = Mock()
+        tools.validators.from_file = Mock()
+        tools.validators.from_file.return_value = validator
+
+        with self.assertRaises(YAMLError):
+            YAMLFile(
+                file=file,
+                schema=schema,
+                tools=tools
+            )
+
+        tools.validators.from_file.assert_called_with(schema)
+
+        file.read.assert_called()
+        parser.as_yaml.assert_called_with(raw)
+
+        validator.is_valid.assert_called_with(yaml)
+
+    def test_schema_satisfied(self):
+        """Checks that the object is created if the data satisfies the given
+        schema.
+        """
+        raw = 'hello: world'
+        yaml = {'hello': 'world'}
+
+        file = Mock()
+        file.read = Mock()
+        file.read.return_value = raw
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        parser = Mock()
+        parser.as_yaml = Mock()
+        parser.as_yaml.return_value = yaml
+
+        tools = Mock()
+        tools.parser = parser
+        tools.validators = Mock()
+        tools.validators.from_file = Mock()
+        tools.validators.from_file.return_value = validator
+
+        result = YAMLFile(
+            file=file,
+            schema=schema,
+            tools=tools
+        )
+
+        self.assertEqual(yaml, result.data)
+
+        tools.validators.from_file.assert_called_with(schema)
+
+        file.read.assert_called()
+        parser.as_yaml.assert_called_with(raw)
+
+        validator.is_valid.assert_called_with(yaml)

--- a/tests/tripleo/intr/insights/test_interpreters.py
+++ b/tests/tripleo/intr/insights/test_interpreters.py
@@ -16,7 +16,7 @@
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from kernel.tools.fs import cd_context_manager
+from kernel.tools.fs import cd
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.interpreters import (EnvironmentInterpreter,
                                            FeatureSetInterpreter,
@@ -46,7 +46,7 @@ class TestEnvironmentInterpreter(TestCase):
         data = {}
 
         with TemporaryDirectory() as tempdir:
-            with cd_context_manager(tempdir):
+            with cd(tempdir):
                 EnvironmentInterpreter(data)
 
 
@@ -72,7 +72,7 @@ class TestFeatureSetInterpreter(TestCase):
         data = {}
 
         with TemporaryDirectory() as tempdir:
-            with cd_context_manager(tempdir):
+            with cd(tempdir):
                 FeatureSetInterpreter(data)
 
 
@@ -98,7 +98,7 @@ class TestNodesInterpreter(TestCase):
         data = {}
 
         with TemporaryDirectory() as tempdir:
-            with cd_context_manager(tempdir):
+            with cd(tempdir):
                 NodesInterpreter(data)
 
 
@@ -123,5 +123,5 @@ class TestReleaseInterpreter(TestCase):
         data = {}
 
         with TemporaryDirectory() as tempdir:
-            with cd_context_manager(tempdir):
+            with cd(tempdir):
                 ReleaseInterpreter(data)

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -17,7 +17,7 @@ from abc import ABC
 from enum import Enum
 from typing import Dict, Iterable, NamedTuple, Optional, Sequence
 
-from kernel.tools.fs import File, cd_context_manager
+from kernel.tools.fs import File, cd
 from kernel.tools.json import Draft7ValidatorFactory, JSONValidatorFactory
 from kernel.tools.yaml import YAML
 from tripleo import __path__ as tripleo_package_path
@@ -61,7 +61,7 @@ class FileInterpreter(ABC):
         if overrides is None:
             overrides = {}
 
-        with cd_context_manager(tripleo_package_path[0]):
+        with cd(tripleo_package_path[0]):
             # the default schemas path are stored in a path relative to the
             # root of the tripleo package. In case the working directory is
             # different, we want them to be reachable


### PR DESCRIPTION
Adding 'GitBackend', an API that allows Cibyl to retrieve and parse Zuul.D files from a Git repository. Alongside it this PR also adds many tools that the backend uses to do its task. Added 'zuuld.json', a schema for Zuul.D files.

The backend is not integrated, cibyl cannot call it yet.