### PR TITLE
Fixing a bug where url validation stopped gerrit urls from being usable

### DIFF
--- a/kernel/tools/urls.py
+++ b/kernel/tools/urls.py
@@ -47,7 +47,7 @@ def is_git(url: URL) -> bool:
     :param url: The URL to test.
     :return: True if the URL points to a git repository, False if not.
     """
-    return url.endswith('.git')
+    return True
 
 
 def is_github(url: URL) -> bool:

--- a/tests/kernel/intr/scm/git/apis/test_utils.py
+++ b/tests/kernel/intr/scm/git/apis/test_utils.py
@@ -23,15 +23,6 @@ class TestGetRepositoryFullname(TestCase):
     """Tests for :class:`get_repository_fullname`.
     """
 
-    def test_error_if_not_git_url(self):
-        """Checks that an error is raised if the URL does not point
-        to a git repository.
-        """
-        url = URL('http://localhost')
-
-        with self.assertRaises(ValueError):
-            get_repository_fullname(url)
-
     def test_gets_fullname(self):
         """Checks that the repository's fullname is retrieved if the URL
         points to a git repo.

--- a/tests/kernel/intr/tools/test_urls.py
+++ b/tests/kernel/intr/tools/test_urls.py
@@ -30,14 +30,6 @@ class TestIsGit(TestCase):
 
         self.assertTrue(is_git(url))
 
-    def test_url_is_not_git(self):
-        """Checks that false if returned if the URL does not point to a git
-        repository.
-        """
-        url = URL('http://localhost')
-
-        self.assertFalse(is_git(url))
-
 
 class TestIsGitHub(TestCase):
     """Tests for :func:`is_github`.


### PR DESCRIPTION
The only common attribute I saw all Git URLs share was that they all ended with a '.git' suffix. Cibyl checked this fact in order to determine if a URL should be handled with a Git backend or something else. Problem is, repositories hosted on Gerrit do not share this fact and have no outstanding detail that can be used to identify them. For this reason, I am removing URL validation for the time being as I am afraid of reducing Cibyl's functionality because of it.

Thing is, this change will probably lead to some regressions, as it is possible for Cibyl now to try handling a random URL with a Git backend. Who knows.