### PR TITLE
Update to tools related to YAML parsing.

### DIFF
--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -19,7 +19,8 @@ from typing import Iterable, Optional
 
 from cibyl.sources.zuuld.models.job import Job
 from kernel.tools.files import FileSearchFactory
-from kernel.tools.fs import Dir, File
+from kernel.tools.fs import Dir, File, KnownDirs, cd
+from kernel.tools.json import Draft7ValidatorFactory
 from kernel.tools.yaml import YAMLArray, YAMLError, YAMLFile
 
 LOG = logging.getLogger(__name__)
@@ -38,11 +39,14 @@ class ZuulDFile(YAMLFile):
         :param tools: Tools this uses to do its task.
         :raises YAMLError: If the file does not meet the schema.
         """
-        super().__init__(
-            file=file,
-            schema=ZuulDFile.SCHEMA,
-            tools=tools
-        )
+        with cd(KnownDirs.CIBYL):
+            validators = Draft7ValidatorFactory()
+
+            super().__init__(
+                file=file,
+                validator=validators.from_file(ZuulDFile.SCHEMA),
+                tools=tools
+            )
 
 
 class ZuulDFileFactory:

--- a/kernel/tools/cache.py
+++ b/kernel/tools/cache.py
@@ -83,6 +83,57 @@ class Cache(Generic[K, V], ABC):
         raise NotImplementedError
 
 
+class CACache(Cache[K, V]):
+    """This implementation follows the Cache-Aside approach to caching.
+    This means that the cache is a simple container for others to push to and
+    pull from. It does not have any responsibility regarding the origin of
+    data and how it is retrieved. Those are up to the user to assume.
+    """
+
+    def __init__(
+        self,
+        storage: Optional[MutableMapping[K, V]] = None
+    ):
+        """Constructor.
+
+        :param storage: Container where the cached data is stored. Be sure
+            that the structure follows the specifications of this class.
+            'None' to let this create its own.
+        """
+        if storage is None:
+            storage = {}
+
+        self._storage = storage
+
+    @property
+    def storage(self):
+        """
+        :return: Container where the cached data is stored. Modifications to
+            this structure can lead to a corrupted cache, use under your own
+            responsibility.
+        """
+        return self._storage
+
+    @overrides
+    def has(self, key: K) -> bool:
+        return key in self.storage
+
+    @overrides
+    def get(self, key: K) -> Optional[V]:
+        return self.storage.get(key)
+
+    @overrides
+    def put(self, key: K, value: V) -> None:
+        self.storage[key] = value
+
+    @overrides
+    def delete(self, key: K) -> None:
+        if key not in self.storage:
+            return
+
+        del self.storage[key]
+
+
 class RTCache(Cache[K, V]):
     """Implementation that follows the Read-Through approach to caching.
     This means that the cache takes responsibility of reaching the

--- a/kernel/tools/json.py
+++ b/kernel/tools/json.py
@@ -15,12 +15,16 @@
 """
 import json
 from abc import ABC, abstractmethod
-from typing import Union
+from dataclasses import dataclass, field
+from typing import Optional, Union
 
 from jsonschema.validators import Draft7Validator
 from overrides import overrides
 
+from kernel.tools.cache import CACache, Cache
 from kernel.tools.fs import File
+from kernel.tools.net import download_into_memory
+from kernel.tools.urls import URL
 
 JSONValidator = Union[Draft7Validator]
 """Possible validators returned by the factory."""
@@ -30,17 +34,58 @@ class JSONValidatorFactory(ABC):
     """Base factory for all JSON validators.
     """
 
+    @dataclass
+    class Caches:
+        files: Cache[File, JSONValidator] = field(
+            default_factory=lambda *_: CACache()
+        )
+        remotes: Cache[URL, JSONValidator] = field(
+            default_factory=lambda *_: CACache()
+        )
+
+    def __init__(self, caches: Optional[Caches] = None):
+        if caches is None:
+            caches = JSONValidatorFactory.Caches()
+
+        self._caches = caches
+
+    @property
+    def caches(self) -> Caches:
+        return self._caches
+
     @abstractmethod
-    def from_file(self, file: File) -> JSONValidator:
+    def from_buffer(self, buffer: Union[bytes, str]) -> JSONValidator:
+        raise NotImplementedError
+
+    def from_file(self, file: File, encoding: str = 'utf-8') -> JSONValidator:
         """Builds a new validator by reading the schema from a file.
 
         :param file: Path to the file to read.
+        :param encoding: Name of the file encoding, like in built-in 'open'.
         :return: New validator instance.
         :raise IOError: If the file could not be opened or read.
         :raise JSONDecodeError: If the file contents are not a valid JSON.
         :raise SchemaError: If the file contents are not a valid JSON schema.
         """
-        raise NotImplementedError
+        cache = self.caches.files
+
+        if cache.has(file):
+            return cache.get(file)
+
+        with open(file, 'r', encoding=encoding) as buffer:
+            validator = self.from_buffer(buffer.read())
+            cache.put(file, validator)
+            return validator
+
+    def from_remote(self, url: URL) -> JSONValidator:
+        cache = self.caches.remotes
+
+        if cache.has(url):
+            return cache.get(url)
+
+        validator = self.from_buffer(download_into_memory(url))
+        cache.put(url, validator)
+        return validator
 
 
 class Draft7ValidatorFactory(JSONValidatorFactory):
@@ -48,10 +93,9 @@ class Draft7ValidatorFactory(JSONValidatorFactory):
     """
 
     @overrides
-    def from_file(self, file: File) -> Draft7Validator:
-        with open(file, 'r') as buffer:
-            schema = json.loads(buffer.read())
+    def from_buffer(self, buffer: Union[bytes, str]) -> Draft7Validator:
+        schema = json.loads(buffer)
 
-            Draft7Validator.check_schema(schema)
+        Draft7Validator.check_schema(schema)
 
-            return Draft7Validator(schema)
+        return Draft7Validator(schema)

--- a/tests/kernel/intr/tools/test_json.py
+++ b/tests/kernel/intr/tools/test_json.py
@@ -23,6 +23,7 @@ from jsonschema.validators import Draft7Validator
 
 from kernel.tools.fs import File
 from kernel.tools.json import Draft7ValidatorFactory
+from kernel.tools.urls import URL
 
 
 class TestDraft7ValidatorFactory(TestCase):
@@ -58,7 +59,7 @@ class TestDraft7ValidatorFactory(TestCase):
             with self.assertRaises(SchemaError):
                 factory.from_file(File(file.name))
 
-    def test_validator_is_build(self):
+    def test_validator_is_built(self):
         """Checks that if all conditions meet, the validator is built.
         """
         data = {
@@ -76,3 +77,34 @@ class TestDraft7ValidatorFactory(TestCase):
 
             self.assertIsInstance(result, Draft7Validator)
             self.assertEqual(result.schema, data)
+
+    def test_validator_is_cached_on_from_file(self):
+        """Checks that the validator built for a file is cached for it.
+        """
+        data = {
+            '$schema': 'some-url',
+            'type': 'string'
+        }
+
+        with NamedTemporaryFile(mode='w') as file:
+            file.write(json.dumps(data))
+            file.flush()
+
+            factory = Draft7ValidatorFactory()
+
+            result1 = factory.from_file(File(file.name))
+            result2 = factory.from_file(File(file.name))
+
+            self.assertEqual(result2, result1)
+
+    def test_validator_is_cached_on_from_remote(self):
+        """Checks that the validator built for a URL is cached for it.
+        """
+        url = URL('https://json.schemastore.org/zuul.json')
+
+        factory = Draft7ValidatorFactory()
+
+        result1 = factory.from_remote(url)
+        result2 = factory.from_remote(url)
+
+        self.assertEqual(result2, result1)

--- a/tests/kernel/unit/tools/test_cache.py
+++ b/tests/kernel/unit/tools/test_cache.py
@@ -16,7 +16,56 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from kernel.tools.cache import CacheError, RTCache
+from kernel.tools.cache import CACache, CacheError, RTCache
+
+
+class TestCACache(TestCase):
+    """Tests for :class:`CACache`.
+    """
+
+    def test_missing_entry(self):
+        """Checks that 'None' is returned for a missing entry.
+        """
+        key = 0
+
+        cache = CACache[int, str]()
+
+        self.assertFalse(cache.has(key))
+        self.assertIsNone(cache.get(key))
+
+    def test_stores_entry(self):
+        """Checks that the cache is capable of storing data within.
+        """
+
+        key = 0
+        value = 'test'
+
+        cache = CACache[int, str]()
+
+        self.assertFalse(cache.has(key))
+
+        cache.put(key, value)
+
+        self.assertTrue(cache.has(key))
+        self.assertEqual(value, cache.get(key))
+
+    def test_deletes_entry(self):
+        """Checks that it is possible to delete data from the cache.
+        """
+        key = 0
+        value = 'test'
+
+        cache = CACache[int, str](
+            storage={
+                key: value
+            }
+        )
+
+        self.assertTrue(cache.has(key))
+
+        cache.delete(key)
+
+        self.assertFalse(cache.has(key))
 
 
 class TestRTCache(TestCase):

--- a/tests/kernel/unit/tools/test_yaml.py
+++ b/tests/kernel/unit/tools/test_yaml.py
@@ -35,7 +35,7 @@ class TestYAMLFile(TestCase):
 
         YAMLFile(
             file=file,
-            schema=None,
+            validator=None,
             tools=tools
         )
 
@@ -51,8 +51,6 @@ class TestYAMLFile(TestCase):
         file.read = Mock()
         file.read.return_value = raw
 
-        schema = Mock()
-
         validator = Mock()
         validator.is_valid = Mock()
         validator.is_valid.return_value = False
@@ -63,18 +61,13 @@ class TestYAMLFile(TestCase):
 
         tools = Mock()
         tools.parser = parser
-        tools.validators = Mock()
-        tools.validators.from_file = Mock()
-        tools.validators.from_file.return_value = validator
 
         with self.assertRaises(YAMLError):
             YAMLFile(
                 file=file,
-                schema=schema,
+                validator=validator,
                 tools=tools
             )
-
-        tools.validators.from_file.assert_called_with(schema)
 
         file.read.assert_called()
         parser.as_yaml.assert_called_with(raw)
@@ -92,8 +85,6 @@ class TestYAMLFile(TestCase):
         file.read = Mock()
         file.read.return_value = raw
 
-        schema = Mock()
-
         validator = Mock()
         validator.is_valid = Mock()
         validator.is_valid.return_value = True
@@ -104,19 +95,14 @@ class TestYAMLFile(TestCase):
 
         tools = Mock()
         tools.parser = parser
-        tools.validators = Mock()
-        tools.validators.from_file = Mock()
-        tools.validators.from_file.return_value = validator
 
         result = YAMLFile(
             file=file,
-            schema=schema,
+            validator=validator,
             tools=tools
         )
 
         self.assertEqual(yaml, result.data)
-
-        tools.validators.from_file.assert_called_with(schema)
 
         file.read.assert_called()
         parser.as_yaml.assert_called_with(raw)


### PR DESCRIPTION
Changes:
- JSONValidatorFactory can now produce schemas from a string, a file or a URL.
- JSONValidatorFactory now caches the validators produced for files and URLs. This way you will not need to access those external resources more than once.
- YAMLFile no longer generates its own schema, but receives one. The origin of the schema is more flexible this way.
- Added  CACache, another implementation of a cache that acts like a simple dictionary.