### PR TITLE
Retrieving manila backend from scenario file

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.6', '3.9']

--- a/tests/tripleo/e2e/test_insights.py
+++ b/tests/tripleo/e2e/test_insights.py
@@ -62,6 +62,22 @@ class TestInsights(TestCase):
 
         self.assertEqual('rbd', result.components.cinder.backend)
 
+    def test_manila_backend(self):
+        """Checks that the manila backend is extracted from a scenario
+        file.
+        """
+        outline = Outline(
+            featureset='config/general_config/featureset052.yml',
+            overrides={
+                'composable_scenario': 'scenario004-standalone.yaml'
+            }
+        )
+
+        lookup = DeploymentLookUp()
+        result = lookup.run(outline)
+
+        self.assertEqual('cephfs', result.components.manila.backend)
+
     def test_neutron_backend(self):
         """Checks that the neutron backend is extracted from a scenario
         file.

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -83,6 +83,13 @@ class DeploymentSummary:
             """Name of the backend supporting glance."""
 
         @dataclass
+        class Manila:
+            """Information on the Manila component.
+            """
+            backend: Optional[str] = None
+            """Name of the backend supporting manila."""
+
+        @dataclass
         class Neutron:
             """Information on the Neutron component.
             """
@@ -103,6 +110,10 @@ class DeploymentSummary:
             default_factory=lambda *_: DeploymentSummary.Components.Glance()
         )
         """Section for the Glance component."""
+        manila: Manila = field(
+            default_factory=lambda *_: DeploymentSummary.Components.Manila()
+        )
+        """Section for the Manila component."""
         neutron: Neutron = field(
             default_factory=lambda *_: DeploymentSummary.Components.Neutron()
         )

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -283,6 +283,7 @@ class DeploymentLookUp:
 
             result.components.cinder.backend = scenario.get_cinder_backend()
             result.components.glance.backend = scenario.get_glance_backend()
+            result.components.manila.backend = scenario.get_manila_backend()
             result.components.neutron.backend = scenario.get_neutron_backend()
             result.components.neutron.ml2_driver = scenario.get_ml2_driver()
 


### PR DESCRIPTION
This PR adds the necessary tools to extract the manila backend from scenario files. Scope is limited to the TripleO library, with integration on Cibyl coming on another PR.