### PR TITLE
Use new elasticsearch index for get_jobs

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -104,7 +104,7 @@ class ElasticSearch(ServerSource):
             self.es_client.disconnect()
 
     @speed_index({'base': 1})
-    def get_jobs(self: object, **kwargs: Argument) -> AttributeDictValue:
+    def get_jobs(self, **kwargs: Argument) -> AttributeDictValue:
         """Get jobs from elasticsearch
 
             :returns: Job objects queried from elasticsearch
@@ -121,7 +121,7 @@ class ElasticSearch(ServerSource):
 
         hits = self.__query_get_hits(
             query=query_body,
-            index='logstash_jenkins_jobs'
+            index='logstash_jenkins_jobs_cibyl'
         )
 
         # make the hits list a flat list of dicts with the job information for


### PR DESCRIPTION
This change simply updates the name of the index and does not modify the
query itself.

The query is quite slow, but I have not found any way to simplify the query and
make sure that the results include all jobs. I think that the best way forward
is to rely on Jenkins source for basic queries like getting jobs and last
builds and using Elasticsearch for more time-consuming ones like getting all
builds and getting openstack information, since  even if the elasticsearch
query is slow, it'll still be faster than getting the information from Jenkins.

