### PR TITLE
Adding abstraction on top of JSON tools.

### DIFF
--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -19,7 +19,6 @@ from collections import UserDict
 from typing import Callable, Optional
 
 import rfc3987
-from jsonschema.exceptions import ValidationError
 
 import cibyl.exceptions.config as conf_exc
 from cibyl import __path__ as pwd
@@ -157,10 +156,8 @@ class AppConfig(Config):
             validators = Draft7ValidatorFactory()
             validator = validators.from_file(self._schema)
 
-            try:
-                validator.validate(self.data)
-            except ValidationError as ex:
-                raise SchemaError(error=ex.message)
+            if not validator.is_valid(self.data):
+                raise SchemaError(error="Invalid configuration file.")
 
 
 class ConfigFactory:

--- a/kernel/tools/json.py
+++ b/kernel/tools/json.py
@@ -28,47 +28,93 @@ from kernel.tools.net import download_into_memory
 from kernel.tools.urls import URL
 
 JSONObj = Dict[str, Any]
+"""Represents an object on a JSON file."""
 JSONArray = List[JSONObj]
+"""Represents an array on a JSON file."""
 JSON = Union[JSONArray, JSONObj]
+"""Represents data originated from a JSON file."""
 JSONSchema = JSON
+"""Represents a schema for a JSON file."""
 
 
 class JSONError(Exception):
-    pass
+    """Describes any error that happened while parsing a stream in JSON
+    format.
+    """
 
 
 class SchemaError(JSONError):
-    pass
+    """Describes any errors related to the parsing or usage of JSON schemas.
+    """
 
 
 class JSONValidator(ABC):
+    """Base class for all tools that take care of facing a JSON file against a
+     schema.
+    """
+
     def __init__(self, schema: JSONSchema):
+        """Constructor.
+
+        :param schema: Schema this will validate data against.
+        """
         self._schema = schema
 
     @property
     def schema(self) -> JSONSchema:
+        """
+        :return: Schema this will validate data against.
+        """
         return self._schema
 
     @abstractmethod
     def is_valid(self, data: JSON) -> bool:
+        """Checks whether some data conforms to the JSON schema represented
+        by this validator.
+
+        :param data: The data to validate.
+        :return: True if it does, False if not.
+        """
         raise NotImplementedError
 
 
 class NullValidator(JSONValidator):
+    """Implementation of a JSON validator that does nothing, just
+    considers all data to be valid. Useful for disabling validation on
+    classes that use it.
+    """
+
     @overrides
     def is_valid(self, data: JSON) -> bool:
         return True
 
 
 class Draft7Validator(JSONValidator):
+    """Implementation of a JSON validator that works with schemas following
+    the draft 7 specification:
+    https://json-schema.org/draft-07/json-schema-release-notes.html.
+    """
 
     def __init__(self, schema: JSONSchema):
+        """Constructor.
+
+        :param schema: Data representing a draft 7 schema.
+        :raises SchemaError:
+            If the schema does not follow the specified draft.
+        """
         super().__init__(schema)
 
         self._check_schema(schema)
         self._validator = JSDraft7Validator(schema)
 
-    def _check_schema(self, schema: JSONSchema):
+    def _check_schema(self, schema: JSONSchema) -> None:
+        """Verifies whether the schema follows the draft required by this
+        class.
+
+        :param schema: The schema to check.
+        :raises SchemaError:
+            If the schema does not follow the draft7 specification.
+        """
         try:
             JSDraft7Validator.check_schema(schema)
         except JSSchemaError as ex:
@@ -170,6 +216,9 @@ class JSONValidatorFactory(ABC):
 
 
 class NullValidatorFactory(JSONValidatorFactory):
+    """Factory for :class:`NullValidator`.
+    """
+
     @overrides
     def from_buffer(self, buffer: Union[bytes, str]) -> JSONValidator:
         return NullValidator(schema=json.loads(buffer))

--- a/kernel/tools/yaml.py
+++ b/kernel/tools/yaml.py
@@ -15,7 +15,7 @@
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional
 
 import yaml
 from cached_property import cached_property
@@ -23,13 +23,14 @@ from overrides import overrides
 from yaml import YAMLError as StandardYAMLError
 
 from kernel.tools.fs import File
-from kernel.tools.json import JSONValidator, JSONValidatorFactory
+from kernel.tools.json import (JSON, JSONArray, JSONObj, JSONValidator,
+                               JSONValidatorFactory)
 
-YAMLObj = Dict[str, Any]
+YAMLObj = JSONObj
 """Represents an object on a YAML file."""
-YAMLArray = List[YAMLObj]
+YAMLArray = JSONArray
 """Represents an array on a YAML file."""
-YAML = Union[YAMLArray, YAMLObj]
+YAML = JSON
 """Represents data originated from a YAML file."""
 
 YAMLValidator = JSONValidator

--- a/tests/kernel/intr/tools/test_json.py
+++ b/tests/kernel/intr/tools/test_json.py
@@ -20,8 +20,96 @@ from unittest import TestCase
 
 from kernel.tools.fs import File
 from kernel.tools.json import (Draft7Validator, Draft7ValidatorFactory,
-                               SchemaError)
+                               NullValidatorFactory, SchemaError)
 from kernel.tools.urls import URL
+
+
+class TestNullValidatorFactory(TestCase):
+    """Tests for :class:`NullValidatorFactory`.
+    """
+
+    class TestDraft7ValidatorFactory(TestCase):
+        """Tests for :class:`Draft7ValidatorFactory`.
+        """
+
+        def test_json_error(self):
+            """Checks that an error is thrown if the file is not formatted as a
+            JSON.
+            """
+            with NamedTemporaryFile('w') as file:
+                file.write('some-text')
+
+                factory = NullValidatorFactory()
+
+                with self.assertRaises(JSONDecodeError):
+                    factory.from_file(File(file.name))
+
+        def test_schema_error(self):
+            """Checks that an error is thrown if the file is a JSON, but not a
+            schema.
+            """
+            data = {
+                'type': 'some-type'
+            }
+
+            with NamedTemporaryFile(mode='w') as file:
+                file.write(json.dumps(data))
+                file.flush()
+
+                factory = NullValidatorFactory()
+
+                with self.assertRaises(SchemaError):
+                    factory.from_file(File(file.name))
+
+        def test_validator_is_built(self):
+            """Checks that if all conditions meet, the validator is built.
+            """
+            data = {
+                '$schema': 'some-url',
+                'type': 'string'
+            }
+
+            with NamedTemporaryFile(mode='w') as file:
+                file.write(json.dumps(data))
+                file.flush()
+
+                factory = NullValidatorFactory()
+
+                result = factory.from_file(File(file.name))
+
+                self.assertIsInstance(result, Draft7Validator)
+                self.assertEqual(result.schema, data)
+
+        def test_validator_is_cached_on_from_file(self):
+            """Checks that the validator built for a file is cached for it.
+            """
+            data = {
+                '$schema': 'some-url',
+                'type': 'string'
+            }
+
+            with NamedTemporaryFile(mode='w') as file:
+                file.write(json.dumps(data))
+                file.flush()
+
+                factory = NullValidatorFactory()
+
+                result1 = factory.from_file(File(file.name))
+                result2 = factory.from_file(File(file.name))
+
+                self.assertEqual(result2, result1)
+
+        def test_validator_is_cached_on_from_remote(self):
+            """Checks that the validator built for a URL is cached for it.
+            """
+            url = URL('https://json.schemastore.org/zuul.json')
+
+            factory = NullValidatorFactory()
+
+            result1 = factory.from_remote(url)
+            result2 = factory.from_remote(url)
+
+            self.assertEqual(result2, result1)
 
 
 class TestDraft7ValidatorFactory(TestCase):

--- a/tests/kernel/intr/tools/test_json.py
+++ b/tests/kernel/intr/tools/test_json.py
@@ -18,11 +18,9 @@ from json import JSONDecodeError
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from jsonschema.exceptions import SchemaError
-from jsonschema.validators import Draft7Validator
-
 from kernel.tools.fs import File
-from kernel.tools.json import Draft7ValidatorFactory
+from kernel.tools.json import (Draft7Validator, Draft7ValidatorFactory,
+                               SchemaError)
 from kernel.tools.urls import URL
 
 

--- a/tests/kernel/unit/tools/test_json.py
+++ b/tests/kernel/unit/tools/test_json.py
@@ -1,0 +1,99 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from kernel.tools.json import Draft7Validator, NullValidator, SchemaError
+
+
+class TestNullValidator(TestCase):
+    """Tests for :class:`NullValidator`.
+    """
+
+    def test_always_returns_true(self):
+        """Checks that the validator will consider all data to be valid.
+        """
+        validator = NullValidator(schema=Mock())
+
+        self.assertTrue(validator.is_valid({}))
+        self.assertTrue(validator.is_valid([{'hello': 'world'}]))
+        self.assertTrue(validator.is_valid(Mock()))
+
+
+class TestDraft7Validator(TestCase):
+    """Tests for :class:`Draft7Validator`.
+    """
+
+    def test_error_on_invalid_schema(self):
+        """Checks that an error is thrown when the schema does not follow
+        the draft 7 specification.
+        """
+        with self.assertRaises(SchemaError):
+            Draft7Validator(schema=Mock())
+
+    def test_fails_on_invalid_data(self):
+        """Checks that the validator will notice when some data does
+        not conform to the schema.
+        """
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties":
+                {
+                    "hello": {
+                        "type": "string",
+                        "const": "world"
+                    },
+                    "additionalProperties": False
+                },
+            "additionalProperties": False
+        }
+
+        data = {
+            'no-hello': '>:['
+        }
+
+        validator = Draft7Validator(schema)
+
+        self.assertFalse(validator.is_valid(data))
+
+    def test_pass_on_valid_data(self):
+        """Checks that the validator will notice when some data does conform
+        to the schema.
+        """
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties":
+                {
+                    "hello": {
+                        "type": "string",
+                        "const": "world"
+                    },
+                    "additionalProperties": False
+                },
+            "additionalProperties": False
+        }
+
+        data = {
+            'hello': 'world'
+        }
+
+        validator = Draft7Validator(schema)
+
+        self.assertTrue(validator.is_valid(data))


### PR DESCRIPTION
On a later PR I am going to need a way to disable validation of JSON files. To do so, I have created a layer on top of our current JSON tools that follows the same interface as the previous implementation but can now be adapted to our needs.