### PR TITLE
Adapt get_tests to new elasticsearch index

### DIFF
--- a/cibyl/sources/zuul/utils/tests/tempest/parser.py
+++ b/cibyl/sources/zuul/utils/tests/tempest/parser.py
@@ -43,10 +43,11 @@ class XMLTempestFailure:
     type: str = field(
         metadata={
             'type': 'Attribute'
-        }
+        },
+        default=""  # in elasticsearch the failure type is often missing
     )
     """The type of error that made the test case fail."""
-    value: str = field()
+    value: str = field(default="")
     """An explanation on why the error happened."""
 
 


### PR DESCRIPTION
Adapt the get_builds method of the Elasticsearch source to work with the
new index. Since we now have unique documents for the (job, build) pair,
get_tests now does not call get_jobs or get_builds explicitely, but rather makes
a new query getting also the job information and creating the
corresponding models, avoiding an uneeded query that adds a large
amount of time. Due to this, the filtering code for builds was refacted
into a function so it could be reused in get_tests.
