### PR TITLE
Differentiating when a Zuul.D file did not met the schema and when it is corrupted.

### DIFF
--- a/cibyl/sources/zuuld/tools/yaml.py
+++ b/cibyl/sources/zuuld/tools/yaml.py
@@ -22,7 +22,7 @@ from overrides import overrides
 from cibyl.sources.zuuld.models.job import Job
 from kernel.tools.files import FileSearchFactory
 from kernel.tools.fs import Dir, File
-from kernel.tools.json import Draft7ValidatorFactory
+from kernel.tools.json import Draft7ValidatorFactory, SchemaError
 from kernel.tools.net import DownloadError
 from kernel.tools.urls import URL
 from kernel.tools.yaml import (YAMLArray, YAMLError, YAMLFile, YAMLValidator,
@@ -122,7 +122,8 @@ class ZuulDFileFactory:
 
         :param file: File that will be tested to see if it is a Zuul.D file.
         :return: The given file, this time cast to a Zuul.D one.
-        :raises YAMLError: If the file does not meet the Zuul.D criteria.
+        :raises SchemaError: If the file does not meet the Zuul.D criteria.
+        :raises YAMLError: If the file could not be read for an unknown reason.
         """
         return ZuulDFile(
             file=file,
@@ -297,10 +298,17 @@ class YAMLSearch:
             try:
                 zuuld = self.tools.files.from_file(file=find)
                 result.append(zuuld)
-            except YAMLError:
+            except SchemaError:
                 LOG.debug(
                     "Ignoring YAML file at '%(find)s' as it does not satisfy "
                     "the Zuul.D file schema.",
+                    {'find': find}
+                )
+                continue
+            except YAMLError:
+                LOG.debug(
+                    "Ignoring YAML file at '%(find)s' for it failed to be "
+                    "parsed.",
                     {'find': find}
                 )
                 continue

--- a/kernel/tools/yaml.py
+++ b/kernel/tools/yaml.py
@@ -23,8 +23,8 @@ from overrides import overrides
 from yaml import YAMLError as StandardYAMLError
 
 from kernel.tools.fs import File
-from kernel.tools.json import (JSON, JSONArray, JSONObj, JSONValidator,
-                               JSONValidatorFactory)
+from kernel.tools.json import (JSON, JSONArray, JSONObj, JSONSchema,
+                               JSONValidator, JSONValidatorFactory)
 
 YAMLObj = JSONObj
 """Represents an object on a YAML file."""
@@ -32,6 +32,8 @@ YAMLArray = JSONArray
 """Represents an array on a YAML file."""
 YAML = JSON
 """Represents data originated from a YAML file."""
+YAMLSchema = JSONSchema
+"""Represents a schema for a YAML file."""
 
 YAMLValidator = JSONValidator
 """Checks that data on a YAML file conforms to a certain structure."""
@@ -42,6 +44,11 @@ YAMLValidatorFactory = JSONValidatorFactory
 class YAMLError(Exception):
     """Describes any errors that happened while parsing a stream in YAML
     format.
+    """
+
+
+class SchemaError(Exception):
+    """Describes any errors related to the parsing or usage of YAML schemas.
     """
 
 
@@ -120,7 +127,7 @@ class YAMLFile:
         does not, returns if it does. In case no schema was provided, this does
         nothing.
 
-        :raises YAMLError: If the data does not meet the schema.
+        :raises SchemaError: If the data does not meet the schema.
         """
         if self.validator is None:
             return
@@ -128,7 +135,7 @@ class YAMLFile:
         if self.validator.is_valid(self.data):
             return
 
-        raise YAMLError(
+        raise SchemaError(
             f"File: '{self.file}' does not conform to schema."
         )
 

--- a/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
+++ b/tests/cibyl/intr/sources/zuuld/tools/test_yaml.py
@@ -18,7 +18,7 @@ from unittest import TestCase
 
 from cibyl.sources.zuuld.tools.yaml import YAMLSearch, ZuulDFile
 from kernel.tools.fs import Dir, File
-from kernel.tools.yaml import YAMLError
+from kernel.tools.yaml import SchemaError
 
 
 class TestZuulDFile(TestCase):
@@ -35,7 +35,7 @@ class TestZuulDFile(TestCase):
             file.write(contents)
             file.flush()
 
-            with self.assertRaises(YAMLError):
+            with self.assertRaises(SchemaError):
                 ZuulDFile(file=File(file.name))
 
 

--- a/tests/kernel/unit/tools/test_yaml.py
+++ b/tests/kernel/unit/tools/test_yaml.py
@@ -16,7 +16,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from kernel.tools.yaml import YAMLError, YAMLFile
+from kernel.tools.yaml import SchemaError, YAMLFile
 
 
 class TestYAMLFile(TestCase):
@@ -62,7 +62,7 @@ class TestYAMLFile(TestCase):
         tools = Mock()
         tools.parser = parser
 
-        with self.assertRaises(YAMLError):
+        with self.assertRaises(SchemaError):
             YAMLFile(
                 file=file,
                 validator=validator,


### PR DESCRIPTION
Adding a new exception type to be able to log when a YAML file does not meet the Zuul.D schema and when it simply could not be read.