### PR TITLE
Update speed index to reflect latest changes

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -248,7 +248,7 @@ class Jenkins(SourceExtension):
                 return True
         return False
 
-    @speed_index({'base': 2, 'release': 3, 'infra_type': 3, 'spec': 3,
+    @speed_index({'base': 2, 'infra_type': 3, 'spec': 3,
                   'ironic_inspector': 3, 'controllers': 3, 'computes': 3,
                   'ml2_driver': 3, 'containers': 3, 'services': 3})
     def get_deployment(self, **kwargs) -> AttributeDictValue:


### PR DESCRIPTION
After changes in elasticsearch source, it's now usable to provide more
information, so the speed index is updated accordingly. The spec
argument still is favoured by the jenkins source since it will be
slightly faster there.
